### PR TITLE
Add support for undecorate-round window style

### DIFF
--- a/src/frame.c
+++ b/src/frame.c
@@ -976,6 +976,7 @@ make_frame (bool mini_p)
   f->horizontal_scroll_bars = false;
   f->want_fullscreen = FULLSCREEN_NONE;
   f->undecorated = false;
+  f->undecorated_round = false;
   f->no_special_glyphs = false;
 #ifndef HAVE_NTGUI
   f->override_redirect = false;
@@ -4056,6 +4057,7 @@ static const struct frame_parm_table frame_parms[] =
   {"tool-bar-position",		SYMBOL_INDEX (Qtool_bar_position)},
   {"inhibit-double-buffering",  SYMBOL_INDEX (Qinhibit_double_buffering)},
   {"undecorated",		SYMBOL_INDEX (Qundecorated)},
+  {"undecorated-round",		SYMBOL_INDEX (Qundecorated_round)},
   {"parent-frame",		SYMBOL_INDEX (Qparent_frame)},
   {"skip-taskbar",		SYMBOL_INDEX (Qskip_taskbar)},
   {"no-focus-on-map",		SYMBOL_INDEX (Qno_focus_on_map)},
@@ -6334,6 +6336,7 @@ syms_of_frame (void)
   DEFSYM (Qicon, "icon");
   DEFSYM (Qminibuffer, "minibuffer");
   DEFSYM (Qundecorated, "undecorated");
+  DEFSYM (Qundecorated_round, "undecorated-round");
   DEFSYM (Qno_special_glyphs, "no-special-glyphs");
   DEFSYM (Qparent_frame, "parent-frame");
   DEFSYM (Qskip_taskbar, "skip-taskbar");

--- a/src/frame.h
+++ b/src/frame.h
@@ -476,6 +476,9 @@ struct frame
   /* True if this is an undecorated frame.  */
   bool_bf undecorated : 1;
 
+  /* True if this is an undecorated frame with round corners.  */
+  bool_bf undecorated_round : 1;
+
 #ifndef HAVE_NTGUI
   /* True if this is an override_redirect frame.  */
   bool_bf override_redirect : 1;
@@ -1273,6 +1276,7 @@ default_pixels_per_inch_y (void)
 
 #if defined (HAVE_WINDOW_SYSTEM)
 #define FRAME_UNDECORATED(f) ((f)->undecorated)
+#define FRAME_UNDECORATED_ROUND(f) ((f)->undecorated_round)
 #ifdef HAVE_NTGUI
 #define FRAME_OVERRIDE_REDIRECT(f) ((void) (f), 0)
 #else

--- a/src/macappkit.m
+++ b/src/macappkit.m
@@ -22,6 +22,7 @@ along with GNU Emacs Mac port.  If not, see <https://www.gnu.org/licenses/>.  */
 
 #include "macterm.h"
 
+#include <AppKit/AppKit.h>
 #include <sys/socket.h>
 
 #include "character.h"
@@ -2513,7 +2514,7 @@ static void mac_move_frame_window_structure_1 (struct frame *, int, int);
   if (!FRAME_TOOLTIP_P (f))
     {
       if (!self.shouldBeTitled)
-	windowStyle = NSWindowStyleMaskBorderless;
+	windowStyle = (NSWindowStyleMaskBorderless | NSWindowStyleMaskResizable);
       else
 	windowStyle = (NSWindowStyleMaskTitled | NSWindowStyleMaskClosable
 		       | NSWindowStyleMaskMiniaturizable
@@ -2521,6 +2522,11 @@ static void mac_move_frame_window_structure_1 (struct frame *, int, int);
     }
   else
     windowStyle = NSWindowStyleMaskBorderless;
+
+  if (FRAME_UNDECORATED_ROUND (f))
+    {
+      windowStyle |= NSFullSizeContentViewWindowMask;
+    }
 
   if (oldWindow == nil)
     {
@@ -2645,6 +2651,14 @@ static void mac_move_frame_window_structure_1 (struct frame *, int, int);
       [window setIgnoresMouseEvents:YES];
       [window setExcludedFromWindowsMenu:YES];
       window.animationBehavior = NSWindowAnimationBehaviorNone;
+    }
+  if (FRAME_UNDECORATED_ROUND (f))
+    {
+      [window setTitlebarAppearsTransparent:YES];
+      [window setTitleVisibility:NSWindowTitleHidden];
+      [[window standardWindowButton:NSWindowCloseButton] setHidden:YES];
+      [[window standardWindowButton:NSWindowMiniaturizeButton] setHidden:YES];
+      [[window standardWindowButton:NSWindowZoomButton] setHidden:YES];
     }
 }
 
@@ -4216,10 +4230,10 @@ static void mac_move_frame_window_structure_1 (struct frame *, int, int);
 - (void)updateWindowStyle
 {
   BOOL shouldBeTitled = self.shouldBeTitled;
+  struct frame *f = emacsFrame;
 
   if (emacsWindow.hasTitleBar != shouldBeTitled)
     {
-      struct frame *f = emacsFrame;
       Lisp_Object tool_bar_lines = get_frame_param (f, Qtool_bar_lines);
 
       if (FIXNUMP (tool_bar_lines) && XFIXNUM (tool_bar_lines) > 0)
@@ -4233,6 +4247,11 @@ static void mac_move_frame_window_structure_1 (struct frame *, int, int);
 	    gui_set_frame_parameters (f, list1 (Fcons (Qtool_bar_lines,
 						       tool_bar_lines)));
 	  });
+      [self setupWindow];
+    }
+
+  if (([emacsWindow styleMask] & NSFullSizeContentViewWindowMask) != FRAME_UNDECORATED_ROUND (f))
+    {
       [self setupWindow];
     }
 

--- a/src/macfns.c
+++ b/src/macfns.c
@@ -1163,6 +1163,19 @@ mac_set_undecorated (struct frame *f, Lisp_Object new_value, Lisp_Object old_val
 }
 
 static void
+mac_set_undecorated_round (struct frame *f, Lisp_Object new_value, Lisp_Object old_value)
+{
+  if (!EQ (new_value, old_value))
+    {
+      FRAME_UNDECORATED_ROUND (f) = NILP (new_value) ? false : true;
+
+      block_input ();
+      mac_update_frame_window_style (f);
+      unblock_input ();
+    }
+}
+
+static void
 mac_set_parent_frame (struct frame *f, Lisp_Object new_value, Lisp_Object old_value)
 {
   struct frame *p = NULL;
@@ -2299,7 +2312,7 @@ DEFUN ("x-create-frame", Fx_create_frame, Sx_create_frame,
   Lisp_Object frame, tem;
   Lisp_Object name;
   bool minibuffer_only = false;
-  bool undecorated = false, override_redirect = false;
+  bool undecorated = false, undecorated_round = false, override_redirect = false;
   long window_prompting = 0;
   specpdl_ref count = SPECPDL_INDEX ();
   Lisp_Object display;
@@ -2392,6 +2405,18 @@ DEFUN ("x-create-frame", Fx_create_frame, Sx_create_frame,
 
   if (!NILP (tem = (gui_display_get_arg (dpyinfo,
                                          parms,
+                                         Qundecorated_round,
+                                         NULL,
+                                         NULL,
+                                         RES_TYPE_BOOLEAN)))
+      && !(BASE_EQ (tem, Qunbound)))
+    undecorated_round = true;
+
+  FRAME_UNDECORATED_ROUND (f) = undecorated_round;
+  store_frame_param (f, Qundecorated_round, undecorated_round ? Qt : Qnil);
+
+  if (!NILP (tem = (gui_display_get_arg (dpyinfo,
+                                         parms,
                                          Qoverride_redirect,
                                          NULL,
                                          NULL,
@@ -2411,7 +2436,7 @@ DEFUN ("x-create-frame", Fx_create_frame, Sx_create_frame,
   FRAME_FONTSET (f) = -1;
   f->output_data.mac->white_relief.pixel = -1;
   f->output_data.mac->black_relief.pixel = -1;
-  FRAME_INTERNAL_TOOL_BAR_P (f) = undecorated || !NILP (parent_frame);
+  FRAME_INTERNAL_TOOL_BAR_P (f) = undecorated || undecorated_round || !NILP (parent_frame);
 
   fset_icon_name (f, gui_display_get_arg (dpyinfo,
                                           parms,
@@ -5270,6 +5295,7 @@ frame_parm_handler mac_frame_parm_handlers[] =
   0, /* mac_set_tool_bar_position, */
   mac_set_inhibit_double_buffering,
   mac_set_undecorated,
+  mac_set_undecorated_round,
   mac_set_parent_frame,
   mac_set_skip_taskbar,
   mac_set_no_focus_on_map,

--- a/src/nsfns.m
+++ b/src/nsfns.m
@@ -1102,6 +1102,7 @@ frame_parm_handler ns_frame_parm_handlers[] =
   ns_set_tool_bar_position,
   ns_set_inhibit_double_buffering,
   ns_set_undecorated,
+  ns_set_undecorated_round,
   ns_set_parent_frame,
   0, /* x_set_skip_taskbar */
   ns_set_no_focus_on_map,
@@ -1404,6 +1405,11 @@ DEFUN ("x-create-frame", Fx_create_frame, Sx_create_frame,
                              RES_TYPE_BOOLEAN);
   FRAME_UNDECORATED (f) = !NILP (tem) && !EQ (tem, Qunbound);
   store_frame_param (f, Qundecorated, FRAME_UNDECORATED (f) ? Qt : Qnil);
+
+  tem = gui_display_get_arg (dpyinfo, parms, Qundecorated_round, NULL, NULL,
+                             RES_TYPE_BOOLEAN);
+  FRAME_UNDECORATED_ROUND (f) = !NILP (tem) && !EQ (tem, Qunbound);
+  store_frame_param (f, Qundecorated_round, FRAME_UNDECORATED_ROUND (f) ? Qt : Qnil);
 
 #ifdef NS_IMPL_COCOA
   tem = gui_display_get_arg (dpyinfo, parms, Qns_appearance, NULL, NULL,

--- a/src/nsterm.h
+++ b/src/nsterm.h
@@ -1226,6 +1226,8 @@ extern void ns_make_frame_invisible (struct frame *f);
 extern void ns_iconify_frame (struct frame *f);
 extern void ns_set_undecorated (struct frame *f, Lisp_Object new_value,
                                 Lisp_Object old_value);
+extern void ns_set_undecorated_round (struct frame *f, Lisp_Object new_value,
+                                Lisp_Object old_value);
 extern void ns_set_parent_frame (struct frame *f, Lisp_Object new_value,
                                  Lisp_Object old_value);
 extern void ns_set_no_focus_on_map (struct frame *f, Lisp_Object new_value,

--- a/src/nsterm.m
+++ b/src/nsterm.m
@@ -1811,6 +1811,44 @@ ns_set_undecorated (struct frame *f, Lisp_Object new_value, Lisp_Object old_valu
 }
 
 void
+ns_set_undecorated_round (struct frame *f, Lisp_Object new_value, Lisp_Object old_value)
+/* --------------------------------------------------------------------------
+     Set frame F's `undecorated_round' parameter.  If non-nil, F's window-system
+     window is drawn without decorations, title, minimize/maximize boxes
+     and external round borders.  This usually means that the window cannot be
+     dragged, resized, iconified, maximized or deleted with the mouse.  If
+     nil, draw the frame with all the elements listed above unless these
+     have been suspended via window manager settings.
+   -------------------------------------------------------------------------- */
+{
+  NSTRACE ("ns_set_undecorated_round");
+
+  if (!EQ (new_value, old_value))
+    {
+      EmacsView *view = (EmacsView *)FRAME_NS_VIEW (f);
+      NSWindow *oldWindow = [view window];
+      NSWindow *newWindow;
+
+      block_input ();
+
+      FRAME_UNDECORATED_ROUND (f) = !NILP (new_value);
+
+      newWindow = [[EmacsWindow alloc] initWithEmacsFrame:f];
+
+      if ([oldWindow isKeyWindow])
+        [newWindow makeKeyAndOrderFront:NSApp];
+
+      [newWindow setIsVisible:[oldWindow isVisible]];
+      if ([oldWindow isMiniaturized])
+        [newWindow miniaturize:NSApp];
+
+      [oldWindow close];
+
+      unblock_input ();
+    }
+}
+
+void
 ns_set_parent_frame (struct frame *f, Lisp_Object new_value, Lisp_Object old_value)
 /* --------------------------------------------------------------------------
      Set frame F's `parent-frame' parameter.  If non-nil, make F a child
@@ -9274,6 +9312,10 @@ ns_in_echo_area (void)
 		 | NSWindowStyleMaskResizable
 		 | NSWindowStyleMaskMiniaturizable
 		 | NSWindowStyleMaskClosable);
+  if (FRAME_UNDECORATED_ROUND (f))
+    {
+      styleMask |= NSFullSizeContentViewWindowMask;
+    }
 
   last_drag_event = nil;
 
@@ -9358,13 +9400,22 @@ ns_in_echo_area (void)
 #endif
     }
 
+  if (FRAME_UNDECORATED_ROUND (f))
+    {
+      [self setTitlebarAppearsTransparent:YES];
+      [self setTitleVisibility:NSWindowTitleHidden];
+      [[self standardWindowButton:NSWindowCloseButton] setHidden:YES];
+      [[self standardWindowButton:NSWindowMiniaturizeButton] setHidden:YES];
+      [[self standardWindowButton:NSWindowZoomButton] setHidden:YES];
+    }
+
   return self;
 }
 
 
 - (void)createToolbar: (struct frame *)f
 {
-  if (FRAME_UNDECORATED (f) || !FRAME_EXTERNAL_TOOL_BAR (f) || [self toolbar] != nil)
+  if (FRAME_UNDECORATED (f) || FRAME_UNDECORATED_ROUND (f) || !FRAME_EXTERNAL_TOOL_BAR (f) || [self toolbar] != nil)
     return;
 
   EmacsView *view = (EmacsView *)FRAME_NS_VIEW (f);


### PR DESCRIPTION
Added frame parameter for undecorated round window style, based on this patch: 
https://github.com/d12frosted/homebrew-emacs-plus/blob/master/patches/emacs-30/round-undecorated-frame.patch
