### PR TITLE
Tweak readme to be more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # emacs-mac
 
-This is an experimental build of the [emacs-mac](https://bitbucket.org/mituharu/emacs-mac) (aka Carbon[^1] Emacs, Emacs-mac) port of emacs, updated for Emacs v30.1.  
+This is an experimental build of the [emacs-mac](https://bitbucket.org/mituharu/emacs-mac) (aka Carbon[^1] Emacs, Emacs-mac) port of emacs, updated for Emacs v30.1.
 
 > [!WARNING]
 > This is an experimental build of `emacs-mac`; there will certainly be bugs. We are looking for feedback and testing from experienced users.  If you are familiar with or willing to learn about running new builds of Emacs under a debugger, perfect.  If you are a Mac developer familiar with ObjC or Mac Window frameworks, even better!  Other users should stick to the official NS build or v29.1 emacs-mac release for now.
@@ -28,16 +28,16 @@ See the `emacs-mac-30_1_exp` branch and the file `README-mac` for compile instru
 ./autogen.sh
 CFLAGS="-O3 -mcpu=native" ./configure --with-native-compilation --with-tree-sitter --with-rsvg --enable-mac-app=yes --without-imagemagic  # or whatever config options you use
 make
-sudo make-install  # optional, compresses EL files and installs some resources in /usr/local/share/emacs/30.1.50
+sudo make install  # optional, compresses EL files and installs some resources in /usr/local/share/emacs/30.1.50
 ```
 
 You'll find the app under `mac`.
 
-Note that, as usual, you sometimes need to:
+If you choose not to `make install`, you may need to:
 
 ```
 ~/code/emacs/emacs-mac/mac
-% ln -s ../native-lisp Emacs.app/Contents/
+% ln -s `pwd`/../native-lisp Emacs.app/Contents/
 ```
 
 to associate the native lisp files.


### PR DESCRIPTION
Correct typo in make install. Clarify that linking native-lisp is not required if doing make install.

Inspired by #6 .