### PR TITLE
Fix occasional hangs when MacOS tries to invoke some callbacks on a dying thread

### DIFF
--- a/src/macappkit.m
+++ b/src/macappkit.m
@@ -16855,9 +16855,6 @@ mac_set_buffer_and_glyph_matrix_access_restricted (bool flag)
 static bool
 mac_try_buffer_and_glyph_matrix_access (void)
 {
-  /* Sometimes we reach here as the thread is being killed, catch that here */
-  if (!current_thread)
-    return false;
   if (mac_buffer_and_glyph_matrix_access_restricted_p)
     return !thread_try_acquire_global_lock ();
 

--- a/src/macappkit.m
+++ b/src/macappkit.m
@@ -16855,6 +16855,9 @@ mac_set_buffer_and_glyph_matrix_access_restricted (bool flag)
 static bool
 mac_try_buffer_and_glyph_matrix_access (void)
 {
+  /* Sometimes we reach here as the thread is being killed, catch that here */
+  if (!current_thread)
+    return false;
   if (mac_buffer_and_glyph_matrix_access_restricted_p)
     return !thread_try_acquire_global_lock ();
 

--- a/src/thread.c
+++ b/src/thread.c
@@ -1144,9 +1144,18 @@ thread_check_current_buffer (struct buffer *buffer)
 }
 
 #ifdef HAVE_MACGUI
+#include <errno.h>
 int
 thread_try_acquire_global_lock (void)
 {
+  /* Sometimes we try to acquire the lock after a lisp thread has
+     completed, but before another lisp thread (like the main lisp
+     thread) has re-acquired the lock and set itself as the
+     current_thread.  Since we often need to access buffer parameters
+     from the current thread, we should not acquire the lock unless one
+     is set. */
+  if (!current_thread)
+    return EBUSY;
   return pthread_mutex_trylock (&global_lock);
 }
 


### PR DESCRIPTION
I've noticed some hangs recently where Emacs was becoming stuck in a signal handling loop - it would segfault, and then the signal handler would segfault...

I traced this to the following sequence of events:

1. emacs-mac implements the buffer as a subclass of NSView, which seems to be what allows using the 'press and hold' function on words. MacOS seems to often call [`NSView::selectedRange`](https://github.com/simmsb/emacs-mac-31/blob/1453b01679a02d6945c43bc01a5b331b81a69954/src/macappkit.m#L7299-L7316) at random times, seemingly for some sort of text completion UI that never appears.
2. Emacs would be fine, up until calling `BUF_BEGV` in [`mac_get_selected_range`](https://github.com/simmsb/emacs-mac-31/blob/1453b01679a02d6945c43bc01a5b331b81a69954/src/macterm.c#L4973), at which point it would segfault when attempting to access `current_thread->m_current_buffer`, due to `current_thread` being `NULL`.
3. Emacs' segfault handler would then run, but then segfault itself, leading to a loop.


The cause for this is that when an Emacs thread finishes its lisp function, it performs some cleanup, part of which is setting `current_thread = NULL` [here](https://github.com/simmsb/emacs-mac-31/blob/1453b01679a02d6945c43bc01a5b331b81a69954/src/thread.c#L835) (current_thread will then be updated the next time another thread takes the global lock).

I've fixed this by simply updating `mac_try_buffer_and_glyph_matrix_access` such that it returns false when current_thread is null, this seems to be okay as `selectedRange` seems to [already have some edge case handling](https://github.com/simmsb/emacs-mac-31/blob/1453b01679a02d6945c43bc01a5b331b81a69954/src/macappkit.m#L7304-L7310) where it returns an empty range