### PR TITLE
Do not use CF_NOESCAPE

### DIFF
--- a/src/mac.c
+++ b/src/mac.c
@@ -138,7 +138,7 @@ mac_string_to_four_char_code (Lisp_Object string, FourCharCode *code)
 
 static bool
 mac_foreach_window_1 (struct window *w,
-		      bool (CF_NOESCAPE ^block) (struct window *))
+		      bool (^block) (struct window *))
 {
   bool cont;
 
@@ -161,7 +161,7 @@ mac_foreach_window_1 (struct window *w,
 
 void
 mac_foreach_window (struct frame *f,
-		    bool (CF_NOESCAPE ^block) (struct window *))
+		    bool (^block) (struct window *))
 {
   AUTO_LIST2 (rest, f->tool_bar_window, f->tab_bar_window);
 
@@ -196,7 +196,7 @@ mac_map_keymap_function (Lisp_Object key, Lisp_Object val,
 
 void
 mac_map_keymap (Lisp_Object map, bool autoload,
-		void (CF_NOESCAPE ^block) (Lisp_Object key, Lisp_Object val))
+		void (^block) (Lisp_Object key, Lisp_Object val))
 {
   map_keymap (map, mac_map_keymap_function, Qnil, block, autoload);
 }

--- a/src/macappkit.m
+++ b/src/macappkit.m
@@ -109,10 +109,10 @@ enum {
   (@"NSTouchBarItemIdentifierCandidateList")
 #endif
 
-static void mac_within_gui_and_here (void (^ CF_NOESCAPE) (void),
-				     void (^ CF_NOESCAPE) (void));
-static void mac_within_gui_allowing_inner_lisp (void (^ CF_NOESCAPE) (void));
-static void mac_within_lisp (void (^ CF_NOESCAPE) (void));
+static void mac_within_gui_and_here (void (^) (void),
+				     void (^) (void));
+static void mac_within_gui_allowing_inner_lisp (void (^) (void));
+static void mac_within_lisp (void (^) (void));
 static void mac_within_lisp_deferred_unless_popup (void (^) (void));
 
 #define MAC_SELECT_ALLOW_LISP_EVALUATION 1
@@ -901,7 +901,7 @@ has_notch_support_p (void)
 
 #if MAC_USE_AUTORELEASE_LOOP
 void
-mac_autorelease_loop (Lisp_Object (CF_NOESCAPE ^body) (void))
+mac_autorelease_loop (Lisp_Object (^body) (void))
 {
   Lisp_Object val;
 
@@ -16638,7 +16638,7 @@ mac_gui_loop_once (void)
    they are retained for non-ARC environments.  */
 
 void
-mac_within_gui (void (^ CF_NOESCAPE block) (void))
+mac_within_gui (void (^block) (void))
 {
   mac_within_gui_and_here (block, NULL);
 }
@@ -16649,8 +16649,8 @@ mac_within_gui (void (^ CF_NOESCAPE block) (void))
    returns when the both executions has finished.  */
 
 static void
-mac_within_gui_and_here (void (^ CF_NOESCAPE block_gui) (void),
-			 void (^ CF_NOESCAPE block_here) (void))
+mac_within_gui_and_here (void (^block_gui) (void),
+			 void (^block_here) (void))
 {
   eassert (!pthread_main_np ());
   eassert (mac_gui_queue.count <= 1);
@@ -16685,7 +16685,7 @@ mac_within_gui_and_here (void (^ CF_NOESCAPE block_gui) (void),
    must not be the GUI thread.  */
 
 static void
-mac_within_gui_allowing_inner_lisp (void (^ CF_NOESCAPE block) (void))
+mac_within_gui_allowing_inner_lisp (void (^block) (void))
 {
   eassert (!pthread_main_np ());
   bool __block completed_p = false;
@@ -16711,7 +16711,7 @@ mac_within_gui_allowing_inner_lisp (void (^ CF_NOESCAPE block) (void))
    etc. in the context of BLOCK.  */
 
 static void
-mac_within_lisp (void (^ CF_NOESCAPE block) (void))
+mac_within_lisp (void (^block) (void))
 {
   eassert (pthread_main_np ());
   eassert (mac_lisp_queue.count == 0);

--- a/src/macterm.h
+++ b/src/macterm.h
@@ -563,9 +563,9 @@ extern struct mac_operating_system_version
 extern Lisp_Object mac_four_char_code_to_string (FourCharCode);
 extern bool mac_string_to_four_char_code (Lisp_Object, FourCharCode *);
 extern void mac_foreach_window (struct frame *,
-				bool (CF_NOESCAPE ^) (struct window *));
+				bool (^) (struct window *));
 extern void mac_map_keymap (Lisp_Object, bool,
-			    void (CF_NOESCAPE ^) (Lisp_Object, Lisp_Object));
+			    void (^) (Lisp_Object, Lisp_Object));
 extern Lisp_Object mac_aedesc_to_lisp (const AEDesc *);
 extern OSErr mac_ae_put_lisp (AEDescList *, UInt32, Lisp_Object);
 extern OSErr create_apple_event_from_lisp (Lisp_Object, AppleEvent *);
@@ -753,7 +753,7 @@ extern void mac_update_accessibility_status (struct frame *);
 extern void mac_start_animation (Lisp_Object, Lisp_Object);
 extern CFTypeRef mac_sound_create (Lisp_Object, Lisp_Object);
 extern void mac_sound_play (CFTypeRef, Lisp_Object, Lisp_Object);
-extern void mac_within_gui (void (^ CF_NOESCAPE block) (void));
+extern void mac_within_gui (void (^block) (void));
 
 #if DRAWING_USE_GCD
 #define MAC_BEGIN_DRAW_TO_FRAME(f, gc, rect, context)			\

--- a/src/nsxwidget.m
+++ b/src/nsxwidget.m
@@ -368,7 +368,7 @@ static NSString *xwScript;
 
 #ifdef HAVE_MACGUI
 static void
-mac_within_gui_check_thread (void (^ CF_NOESCAPE block) (void))
+mac_within_gui_check_thread (void (^block) (void))
 {
   if (!pthread_main_np ())
     mac_within_gui (block);


### PR DESCRIPTION
CF_NOESCAPE is __attribute__ ((noescape)), and there is at least
one place where the promise that the block does not escape is
not true because it is stored in a queue. This leads to
undefined behavior when compiled with non-Apple clang.

* src/mac.c (mac_foreach_window_1):
(mac_foreach_window):
(mac_map_keymap):
* src/macappkit.m (NS_TOUCH_BAR_ITEM_IDENTIFIER_CANDIDATE_LIST):
(mac_autorelease_loop):
(mac_within_gui):
(mac_within_gui_and_here):
(mac_within_gui_allowing_inner_lisp):
(mac_within_lisp):
* src/macgui.h (CF_NOESCAPE):
* src/macterm.h:
* src/nsxwidget.m (mac_within_gui_check_thread):