### PR TITLE
Support 'dots' and 'dashes' underline styles

### DIFF
--- a/src/macterm.c
+++ b/src/macterm.c
@@ -64,6 +64,13 @@ static Lisp_Object x_display_rdb_list;
 /* This is display since Mac does not support multiple ones.  */
 struct mac_display_info one_mac_display_info;
 
+/* Patterns for CGContextSetLineDash for dotted and dashed
+   underlines. The first number is the length of the drawn segment, the
+   second the length of the gap between.  */
+
+static const CGFloat mac_underdot_pattern[2] = { 1, 2 };
+static const CGFloat mac_underdash_pattern[2] = { 3, 2 };
+
 /* The keysyms to use for the various modifiers.  */
 
 static struct terminal *mac_create_terminal (struct mac_display_info *dpyinfo);
@@ -378,6 +385,33 @@ mac_draw_horizontal_wave (struct frame *f, GC gc, int x, int y,
 	gx1 += gperiod;
 	CGContextAddLineToPoint (context, gx1, gy1);
       }
+    CGContextStrokePath (context);
+  }
+  MAC_END_DRAW_TO_FRAME (f);
+}
+
+static void
+mac_draw_dashed_line (struct frame *f, GC gc, int x, int y, int width,
+		      CGFloat thickness, const CGFloat *pattern)
+{
+  CGRect clip = CGRectMake (x, y, width, thickness * 2);
+
+  MAC_BEGIN_DRAW_TO_FRAME (f, gc, clip, context);
+  {
+    CGFloat gxmax, gy, gpattern[2];
+
+    gxmax = CGRectGetMaxX (clip);
+    gy = y + (thickness / 2);
+    // Make the segments proportionate to thickness.
+    gpattern[0] = pattern[0] * thickness;
+    gpattern[1] = pattern[1] * thickness;
+
+    CGContextClipToRect (context, clip);
+    CGContextMoveToPoint (context, x, gy);
+    CGContextAddLineToPoint (context, gxmax, gy);
+    CGContextSetStrokeColorWithColor (context, gc->cg_fore_color);
+    CGContextSetLineWidth (context, thickness);
+    CGContextSetLineDash (context, 0, gpattern, 2);
     CGContextStrokePath (context);
   }
   MAC_END_DRAW_TO_FRAME (f);
@@ -2240,6 +2274,13 @@ mac_draw_underwave (struct glyph_string *s, int decoration_width)
 			    decoration_width, wave_height, wave_length);
 }
 
+static void
+mac_draw_underdash (struct glyph_string *s, int decoration_width, int y,
+		    CGFloat thickness, const CGFloat *pattern)
+{
+    mac_draw_dashed_line (s->f, s->gc, s->x, y, decoration_width,
+			  thickness, pattern);
+}
 
 /* Draw glyph string S.  */
 
@@ -2379,10 +2420,14 @@ mac_draw_glyph_string (struct glyph_string *s)
 		  mac_set_foreground (s->gc, xgcv.foreground);
 		}
 	    }
-	  else if (s->face->underline == FACE_UNDERLINE_SINGLE)
+	  else if (s->face->underline == FACE_UNDERLINE_SINGLE
+		   || s->face->underline == FACE_UNDERLINE_DOTS
+		   || s->face->underline == FACE_UNDERLINE_DASHES)
 	    {
 	      unsigned long thickness, position;
 	      int y;
+	      bool did_set_foreground = false;
+	      XGCValues xgcv;
 
               if (s->prev
 		  && s->prev->face->underline == FACE_UNDERLINE_SINGLE
@@ -2464,16 +2509,27 @@ mac_draw_glyph_string (struct glyph_string *s)
 	      s->underline_thickness = thickness;
 	      s->underline_position = position;
 	      y = s->ybase + position;
-	      if (s->face->underline_defaulted_p)
+
+	      if (!s->face->underline_defaulted_p)
+		{
+		  mac_get_gc_values (s->gc, GCForeground, &xgcv);
+		  mac_set_foreground (s->gc, s->face->underline_color);
+		  did_set_foreground = true;
+		}
+
+	      if (s->face->underline == FACE_UNDERLINE_SINGLE)
 		mac_fill_rectangle (s->f, s->gc, s->x, y, s->width, thickness);
 	      else
 		{
-		  XGCValues xgcv;
-		  mac_get_gc_values (s->gc, GCForeground, &xgcv);
-		  mac_set_foreground (s->gc, s->face->underline_color);
-		  mac_fill_rectangle (s->f, s->gc, s->x, y, s->width, thickness);
-		  mac_set_foreground (s->gc, xgcv.foreground);
+		  const CGFloat *pattern =
+		    (s->face->underline == FACE_UNDERLINE_DOTS)
+		    ? mac_underdot_pattern : mac_underdash_pattern;
+		  mac_draw_underdash (s, decoration_width, y,
+				      thickness, pattern);
 		}
+
+	      if (did_set_foreground)
+		mac_set_foreground (s->gc, xgcv.foreground);
 	    }
 	}
 

--- a/src/macterm.c
+++ b/src/macterm.c
@@ -2282,6 +2282,133 @@ mac_draw_underdash (struct glyph_string *s, int decoration_width, int y,
 			  thickness, pattern);
 }
 
+static void
+mac_draw_underline (struct glyph_string *s, int decoration_width)
+{
+  unsigned long thickness, position;
+  int y;
+  bool did_set_foreground = false;
+  XGCValues xgcv;
+  const CGFloat *pattern = mac_underdot_pattern;
+
+  if (s->prev
+      && s->prev->face->underline == FACE_UNDERLINE_SINGLE
+      && (s->prev->face->underline_at_descent_line_p
+	  == s->face->underline_at_descent_line_p)
+      && (s->prev->face->underline_pixels_above_descent_line
+	  == s->face->underline_pixels_above_descent_line))
+    {
+      /* We use the same underline style as the previous one.  */
+      thickness = s->prev->underline_thickness;
+      position = s->prev->underline_position;
+    }
+  else
+    {
+      struct font *font = font_for_underline_metrics (s);
+
+      unsigned long minimum_offset;
+      bool underline_at_descent_line;
+      bool use_underline_position_properties;
+      Lisp_Object val = (WINDOW_BUFFER_LOCAL_VALUE
+			 (Qunderline_minimum_offset, s->w));
+
+      if (FIXNUMP (val))
+	minimum_offset = max (0, XFIXNUM (val));
+      else
+	minimum_offset = 1;
+
+      val = (WINDOW_BUFFER_LOCAL_VALUE
+	     (Qx_underline_at_descent_line, s->w));
+      underline_at_descent_line
+	= (!(NILP (val) || BASE_EQ (val, Qunbound))
+	   || s->face->underline_at_descent_line_p);
+
+      val = (WINDOW_BUFFER_LOCAL_VALUE
+	     (Qx_use_underline_position_properties, s->w));
+      use_underline_position_properties
+	= !(NILP (val) || BASE_EQ (val, Qunbound));
+
+      /* Get the underline thickness.  Default is 1 pixel.  */
+      if (font && font->underline_thickness > 0)
+	thickness = font->underline_thickness;
+      else
+	thickness = 1;
+      if (underline_at_descent_line)
+	position = ((s->height - thickness)
+		    - (s->ybase - s->y)
+		    - s->face->underline_pixels_above_descent_line);
+      else
+	{
+	  /* Get the underline position.  This is the
+	     recommended vertical offset in pixels from
+	     the baseline to the top of the underline.
+	     This is a signed value according to the
+	     specs, and its default is
+
+	     ROUND ((maximum descent) / 2), with
+	     ROUND(x) = floor (x + 0.5)  */
+
+	  if (use_underline_position_properties
+	      && font && font->underline_position >= 0)
+	    position = font->underline_position;
+	  else if (font)
+	    position = (font->descent + 1) / 2;
+	  else
+	    position = minimum_offset;
+	}
+
+      /* Ignore minimum_offset if the amount of pixels was
+	 explicitly specified.  */
+      if (!s->face->underline_pixels_above_descent_line)
+	position = max (position, minimum_offset);
+    }
+
+  /* Check the sanity of thickness and position.  We should
+     avoid drawing underline out of the current line area.  */
+  if (s->y + s->height <= s->ybase + position)
+    position = (s->height - 1) - (s->ybase - s->y);
+  if (s->y + s->height < s->ybase + position + thickness)
+    thickness = (s->y + s->height) - (s->ybase + position);
+  s->underline_thickness = thickness;
+  s->underline_position = position;
+  y = s->ybase + position;
+
+  if (!s->face->underline_defaulted_p)
+    {
+      mac_get_gc_values (s->gc, GCForeground, &xgcv);
+      mac_set_foreground (s->gc, s->face->underline_color);
+      did_set_foreground = true;
+    }
+
+  switch (s->face->underline)
+    {
+    case FACE_UNDERLINE_DOUBLE_LINE:
+      mac_fill_rectangle (s->f, s->gc, s->x, y - thickness - 1,
+			  s->width, thickness);
+      FALLTHROUGH;
+
+    case FACE_UNDERLINE_SINGLE:
+      mac_fill_rectangle (s->f, s->gc, s->x, y, s->width, thickness);
+      break;
+
+    case FACE_UNDERLINE_DASHES:
+      pattern = mac_underdash_pattern;
+      FALLTHROUGH;
+
+    case FACE_UNDERLINE_DOTS:
+      mac_draw_underdash (s, decoration_width, y,
+			  thickness, pattern);
+      break;
+
+    default:
+      /* Wave style was previously handled. */
+      break;
+    }
+
+  if (did_set_foreground)
+    mac_set_foreground (s->gc, xgcv.foreground);
+}
+
 /* Draw glyph string S.  */
 
 static void
@@ -2420,117 +2547,8 @@ mac_draw_glyph_string (struct glyph_string *s)
 		  mac_set_foreground (s->gc, xgcv.foreground);
 		}
 	    }
-	  else if (s->face->underline == FACE_UNDERLINE_SINGLE
-		   || s->face->underline == FACE_UNDERLINE_DOTS
-		   || s->face->underline == FACE_UNDERLINE_DASHES)
-	    {
-	      unsigned long thickness, position;
-	      int y;
-	      bool did_set_foreground = false;
-	      XGCValues xgcv;
-
-              if (s->prev
-		  && s->prev->face->underline == FACE_UNDERLINE_SINGLE
-		  && (s->prev->face->underline_at_descent_line_p
-		      == s->face->underline_at_descent_line_p)
-		  && (s->prev->face->underline_pixels_above_descent_line
-		      == s->face->underline_pixels_above_descent_line))
-		{
-		  /* We use the same underline style as the previous one.  */
-		  thickness = s->prev->underline_thickness;
-		  position = s->prev->underline_position;
-		}
-	      else
-		{
-		  struct font *font = font_for_underline_metrics (s);
-
-		  unsigned long minimum_offset;
-		  bool underline_at_descent_line;
-		  bool use_underline_position_properties;
-		  Lisp_Object val = (WINDOW_BUFFER_LOCAL_VALUE
-				     (Qunderline_minimum_offset, s->w));
-
-		  if (FIXNUMP (val))
-		    minimum_offset = max (0, XFIXNUM (val));
-		  else
-		    minimum_offset = 1;
-
-		  val = (WINDOW_BUFFER_LOCAL_VALUE
-			 (Qx_underline_at_descent_line, s->w));
-		  underline_at_descent_line
-		    = (!(NILP (val) || BASE_EQ (val, Qunbound))
-		       || s->face->underline_at_descent_line_p);
-
-		  val = (WINDOW_BUFFER_LOCAL_VALUE
-			 (Qx_use_underline_position_properties, s->w));
-		  use_underline_position_properties
-		    = !(NILP (val) || BASE_EQ (val, Qunbound));
-
-		  /* Get the underline thickness.  Default is 1 pixel.  */
-                  if (font && font->underline_thickness > 0)
-                    thickness = font->underline_thickness;
-		  else
-		    thickness = 1;
-		  if (underline_at_descent_line)
-		    position = ((s->height - thickness)
-				- (s->ybase - s->y)
-				- s->face->underline_pixels_above_descent_line);
-		  else
-		    {
-                      /* Get the underline position.  This is the
-                         recommended vertical offset in pixels from
-                         the baseline to the top of the underline.
-                         This is a signed value according to the
-                         specs, and its default is
-
-			 ROUND ((maximum descent) / 2), with
-			 ROUND(x) = floor (x + 0.5)  */
-
-		      if (use_underline_position_properties
-                          && font && font->underline_position >= 0)
-                        position = font->underline_position;
-                      else if (font)
-                        position = (font->descent + 1) / 2;
-		      else
-			position = minimum_offset;
-		    }
-
-		  /* Ignore minimum_offset if the amount of pixels was
-		     explicitly specified.  */
-		  if (!s->face->underline_pixels_above_descent_line)
-		    position = max (position, minimum_offset);
-		}
-	      /* Check the sanity of thickness and position.  We should
-		 avoid drawing underline out of the current line area.  */
-	      if (s->y + s->height <= s->ybase + position)
-		position = (s->height - 1) - (s->ybase - s->y);
-	      if (s->y + s->height < s->ybase + position + thickness)
-		thickness = (s->y + s->height) - (s->ybase + position);
-	      s->underline_thickness = thickness;
-	      s->underline_position = position;
-	      y = s->ybase + position;
-
-	      if (!s->face->underline_defaulted_p)
-		{
-		  mac_get_gc_values (s->gc, GCForeground, &xgcv);
-		  mac_set_foreground (s->gc, s->face->underline_color);
-		  did_set_foreground = true;
-		}
-
-	      if (s->face->underline == FACE_UNDERLINE_SINGLE)
-		mac_fill_rectangle (s->f, s->gc, s->x, y, s->width, thickness);
-	      else
-		{
-		  const CGFloat *pattern =
-		    (s->face->underline == FACE_UNDERLINE_DOTS)
-		    ? mac_underdot_pattern : mac_underdash_pattern;
-		  mac_draw_underdash (s, decoration_width, y,
-				      thickness, pattern);
-		}
-
-	      if (did_set_foreground)
-		mac_set_foreground (s->gc, xgcv.foreground);
-	    }
+	  else
+	    mac_draw_underline (s, decoration_width);
 	}
 
       /* Draw overline.  */
@@ -6015,7 +6033,7 @@ default line thickness is used. Otherwise, a floating point number
 should be specified, where 1.0 is the default, with smaller values
 thinner, and larger values thicker. */);
   Vmac_underwave_thickness = Qnil;
-  
+
   DEFVAR_BOOL ("mac-redisplay-dont-reset-vscroll", mac_redisplay_dont_reset_vscroll,
 	       doc: /* Non-nil means update doesn't reset vscroll.  */);
   mac_redisplay_dont_reset_vscroll = false;


### PR DESCRIPTION
This adds support for the new face underline styles, `(:style dots)` and `(:style dashes)`.

Shown here applied as overlays, with the default color `(:underline (:style dots))` and with a custom color `(:underline (:style dots :color "magenta"))`.

<img width="615" height="431" alt="Screenshot 2025-08-11 at 6 26 51 PM" src="https://github.com/user-attachments/assets/110e5ff0-8b0e-4f00-aace-74429246af13" />
