### PR TITLE
fix(menu-bar): Don't update windowMenu if there are no items

### DIFF
--- a/src/macappkit.m
+++ b/src/macappkit.m
@@ -11376,7 +11376,7 @@ mac_fill_menubar (widget_value *first_wv, bool deep_p)
 
 	  [NSApp setMainMenu:newMenu];
 
-	  if (windowMenu)
+	  if (windowMenu && [windowMenu numberOfItems])
 	    [NSApp setWindowsMenu:windowMenu];
 
 	  if (helpMenu)


### PR DESCRIPTION
On MacOS Ventura, we discovered that Emacs app crashes when updating the menubar with empty MenuItems.

Fixes #64.