### PR TITLE
feat: Add transparent title bar

### DIFF
--- a/doc/emacs/macport.texi
+++ b/doc/emacs/macport.texi
@@ -539,6 +539,13 @@ title/tool/tab bars look slightly colored with the value of the
 @code{scroll-bar-background} frame parameter (or the frame background
 color) if the frame is focused and not in fullscreen.
 
+@vindex mac-transparent-titlebar
+ The title bar transparency can be controlled by the value of the
+@code{mac-transparent-titlebar} frame parameter.  If it is @code{nil},
+which is the default then title bar uses system color for its
+background.  If it is non-@code{nil} then the frame background color is
+used instead.
+
 @node Mac Fullscreen
 @section Fullscreen support on the Mac Port
 @cindex fullscreen support (Mac port)

--- a/doc/lispref/frames.texi
+++ b/doc/lispref/frames.texi
@@ -2307,6 +2307,7 @@ application's window.  (It is not certain this will be implemented; try
 it and see if it works.)
 @end ignore
 
+@ignore
 @vindex ns-appearance@r{, a frame parameter}
 @item ns-appearance
 Only available on macOS, if set to @code{dark} draw this frame's
@@ -2318,6 +2319,9 @@ background.
 
 @vindex ns-transparent-titlebar@r{, a frame parameter}
 @item ns-transparent-titlebar
+@end ignore
+@vindex mac-transparent-titlebar@r{, a frame parameter}
+@item mac-transparent-titlebar
 Only available on macOS, if non-@code{nil}, set the titlebar and
 toolbar to be transparent.  This effectively sets the background color
 of both to match the Emacs background color.

--- a/doc/lispref/frames.texi
+++ b/doc/lispref/frames.texi
@@ -2307,7 +2307,6 @@ application's window.  (It is not certain this will be implemented; try
 it and see if it works.)
 @end ignore
 
-@ignore
 @vindex ns-appearance@r{, a frame parameter}
 @item ns-appearance
 Only available on macOS, if set to @code{dark} draw this frame's
@@ -2319,9 +2318,6 @@ background.
 
 @vindex ns-transparent-titlebar@r{, a frame parameter}
 @item ns-transparent-titlebar
-@end ignore
-@vindex mac-transparent-titlebar@r{, a frame parameter}
-@item mac-transparent-titlebar
 Only available on macOS, if non-@code{nil}, set the titlebar and
 toolbar to be transparent.  This effectively sets the background color
 of both to match the Emacs background color.

--- a/src/frame.c
+++ b/src/frame.c
@@ -997,6 +997,8 @@ make_frame (bool mini_p)
 #ifdef NS_IMPL_COCOA
   f->ns_appearance = ns_appearance_system_default;
   f->ns_transparent_titlebar = false;
+#else
+  f->mac_transparent_titlebar = true;
 #endif
 #endif
   f->select_mini_window_flag = false;
@@ -4073,6 +4075,8 @@ static const struct frame_parm_table frame_parms[] =
 #ifdef NS_IMPL_COCOA
   {"ns-appearance",		SYMBOL_INDEX (Qns_appearance)},
   {"ns-transparent-titlebar",	SYMBOL_INDEX (Qns_transparent_titlebar)},
+#else
+  {"mac-transparent-titlebar",  SYMBOL_INDEX (Qmac_transparent_titlebar)},
 #endif
 };
 
@@ -6427,6 +6431,8 @@ syms_of_frame (void)
 #ifdef NS_IMPL_COCOA
   DEFSYM (Qns_appearance, "ns-appearance");
   DEFSYM (Qns_transparent_titlebar, "ns-transparent-titlebar");
+#else
+  DEFSYM (Qmac_transparent_titlebar, "mac-transparent-titlebar");
 #endif
 
   DEFSYM (Qalpha, "alpha");

--- a/src/frame.c
+++ b/src/frame.c
@@ -999,7 +999,7 @@ make_frame (bool mini_p)
   f->ns_transparent_titlebar = false;
 #endif
 #ifdef HAVE_MACGUI
-  f->mac_transparent_titlebar = true;
+  f->mac_transparent_titlebar = false;
 #endif
 #endif
   f->select_mini_window_flag = false;

--- a/src/frame.c
+++ b/src/frame.c
@@ -997,7 +997,8 @@ make_frame (bool mini_p)
 #ifdef NS_IMPL_COCOA
   f->ns_appearance = ns_appearance_system_default;
   f->ns_transparent_titlebar = false;
-#else
+#endif
+#ifdef HAVE_MACGUI
   f->mac_transparent_titlebar = true;
 #endif
 #endif
@@ -4075,7 +4076,8 @@ static const struct frame_parm_table frame_parms[] =
 #ifdef NS_IMPL_COCOA
   {"ns-appearance",		SYMBOL_INDEX (Qns_appearance)},
   {"ns-transparent-titlebar",	SYMBOL_INDEX (Qns_transparent_titlebar)},
-#else
+#endif
+#ifdef HAVE_MACGUI
   {"mac-transparent-titlebar",  SYMBOL_INDEX (Qmac_transparent_titlebar)},
 #endif
 };
@@ -6431,7 +6433,8 @@ syms_of_frame (void)
 #ifdef NS_IMPL_COCOA
   DEFSYM (Qns_appearance, "ns-appearance");
   DEFSYM (Qns_transparent_titlebar, "ns-transparent-titlebar");
-#else
+#endif
+#ifdef HAVE_MACGUI
   DEFSYM (Qmac_transparent_titlebar, "mac-transparent-titlebar");
 #endif
 

--- a/src/frame.h
+++ b/src/frame.h
@@ -744,7 +744,8 @@ struct frame
   /* NSAppearance theme used on this frame.  */
   enum ns_appearance_type ns_appearance;
   bool_bf ns_transparent_titlebar;
-#else
+#endif
+#ifdef HAVE_MACGUI
   bool_bf mac_transparent_titlebar;
 #endif
 

--- a/src/frame.h
+++ b/src/frame.h
@@ -744,6 +744,8 @@ struct frame
   /* NSAppearance theme used on this frame.  */
   enum ns_appearance_type ns_appearance;
   bool_bf ns_transparent_titlebar;
+#else
+  bool_bf mac_transparent_titlebar;
 #endif
 
 #ifdef HAVE_TEXT_CONVERSION

--- a/src/macappkit.m
+++ b/src/macappkit.m
@@ -2566,6 +2566,10 @@ static void mac_move_frame_window_structure_1 (struct frame *, int, int);
 
   window.contentView = visualEffectView;
   MRC_RELEASE (visualEffectView);
+
+  if ([window respondsToSelector:@selector(titlebarAppearsTransparent)])
+    [window setTitlebarAppearsTransparent:FRAME_MAC_TRANSPARENT_TITLEBAR(f)];
+
   FRAME_BACKGROUND_ALPHA_ENABLED_P (f) = true;
   if (FRAME_MAC_DOUBLE_BUFFERED_P (f))
     {
@@ -4284,6 +4288,16 @@ mac_set_frame_window_modified (struct frame *f, bool modified)
   NSWindow *window = FRAME_MAC_WINDOW_OBJECT (f);
 
   mac_within_gui (^{[window setDocumentEdited:modified];});
+}
+
+void
+mac_set_frame_window_transparent_titlebar (struct frame *f, bool transparent)
+{
+  NSWindow *window = FRAME_MAC_WINDOW_OBJECT (f);
+
+  mac_within_gui (^{
+      if ([window respondsToSelector: @selector(titlebarAppearsTransparent)])
+	[window setTitlebarAppearsTransparent:transparent];});
 }
 
 void

--- a/src/macfns.c
+++ b/src/macfns.c
@@ -5273,7 +5273,8 @@ frame_parm_handler mac_frame_parm_handlers[] =
 #ifdef NS_IMPL_COCOA
   NULL, /* ns_set_apperance */
   NULL, /* ns_tranaprent_titlebar */
-#else
+#endif
+#ifdef HAVE_MACGUI
   mac_set_transparent_titlebar,
 #endif
 };

--- a/src/macfns.c
+++ b/src/macfns.c
@@ -1215,6 +1215,20 @@ mac_set_override_redirect (struct frame *f, Lisp_Object new_value, Lisp_Object o
     }
 }
 
+static void
+mac_set_transparent_titlebar (struct frame *f, Lisp_Object new_value, Lisp_Object old_value)
+{
+  if (!EQ (new_value, old_value))
+    {
+      bool transparent = NILP (new_value) ? false : true;
+      FRAME_MAC_TRANSPARENT_TITLEBAR (f) = transparent;
+
+      block_input ();
+      mac_set_frame_window_transparent_titlebar (f, transparent);
+      unblock_input ();
+    }
+}
+
 /* Functions called only from `gui_set_frame_parameters'
    to set individual parameters.
 
@@ -2529,6 +2543,12 @@ DEFUN ("x-create-frame", Fx_create_frame, Sx_create_frame,
   mac_default_scroll_bar_color_parameter (f, parms, Qscroll_bar_background,
 					  "scrollBarBackground",
 					  "ScrollBarBackground", false);
+
+  tem = gui_display_get_arg (dpyinfo, parms, Qmac_transparent_titlebar,
+			     NULL, NULL, RES_TYPE_BOOLEAN);
+  FRAME_MAC_TRANSPARENT_TITLEBAR (f) = !NILP (tem) && !EQ (tem, Qunbound);
+  store_frame_param (f, Qmac_transparent_titlebar,
+		     FRAME_MAC_TRANSPARENT_TITLEBAR (f) ? Qt : Qnil);
 
   /* Init faces before gui_default_parameter is called for the
      scroll-bar-width parameter because otherwise we end up in
@@ -5247,7 +5267,15 @@ frame_parm_handler mac_frame_parm_handlers[] =
   gui_set_no_special_glyphs,
   gui_set_alpha_background,
   NULL, /* mac_set_use_frame_synchronization */
+#ifdef HAVE_X_WINDOWS
   NULL, /* mac_set_shaded */
+#endif
+#ifdef NS_IMPL_COCOA
+  NULL, /* ns_set_apperance */
+  NULL, /* ns_tranaprent_titlebar */
+#else
+  mac_set_transparent_titlebar,
+#endif
 };
 
 void

--- a/src/macfns.c
+++ b/src/macfns.c
@@ -5267,16 +5267,13 @@ frame_parm_handler mac_frame_parm_handlers[] =
   gui_set_no_special_glyphs,
   gui_set_alpha_background,
   NULL, /* mac_set_use_frame_synchronization */
-#ifdef HAVE_X_WINDOWS
-  NULL, /* mac_set_shaded */
-#endif
-#ifdef NS_IMPL_COCOA
-  NULL, /* ns_set_apperance */
-  NULL, /* ns_tranaprent_titlebar */
-#endif
-#ifdef HAVE_MACGUI
+  /* Skipping the following parameters from frame_parms that are not
+     compiled when HAVE_MACGUI is defined:
+     shaded
+     ns-appearance
+     ns-transparent-titlebar
+   */
   mac_set_transparent_titlebar,
-#endif
 };
 
 void

--- a/src/macterm.h
+++ b/src/macterm.h
@@ -339,6 +339,9 @@ struct mac_output
 #define FRAME_MAC_DOUBLE_BUFFERED_P(f) \
   ((f)->output_data.mac->double_buffered_p)
 
+#define FRAME_MAC_TRANSPARENT_TITLEBAR(f) \
+  ((f)->mac_transparent_titlebar)
+
 /* This gives the mac_display_info structure for the display F is on.  */
 #define FRAME_DISPLAY_INFO(f) ((void) (f), (&one_mac_display_info))
 
@@ -620,6 +623,7 @@ extern OSStatus install_application_handler (void);
 extern Lisp_Object mac_application_state (void);
 extern void mac_set_frame_window_title (struct frame *, CFStringRef);
 extern void mac_set_frame_window_modified (struct frame *, bool);
+extern void mac_set_frame_window_transparent_titlebar (struct frame *, bool);
 extern void mac_set_frame_window_proxy (struct frame *, CFURLRef);
 extern bool mac_is_frame_window_visible (struct frame *);
 extern bool mac_is_frame_window_collapsed (struct frame *);


### PR DESCRIPTION
The implementation mechanic is inspired by the one in NS (for
`ns-transparent-titlebar`).  However, a GUI thread is used to actually
apply the value to a frame (window in macOS parlance).  This has a
slight difference, where the value can be set in a model of a frame, but
title bar transparency will not be rendered in the GUI.

I have tested it with `emacs -Q`, then:

``` emacs-lisp
(make-frame '((mac-transparent-titlebar . t)
              (background-color . "green")))
;; => a new frame with a green background and green titlebar has been created; close the frame

(let ((default-frame-alist '((mac-transparent-titlebar . t))))
  (make-frame '((background-color . "blue"))))
;; => a new frame with a blue background and blue titlebar has been created; close the frame

(set-frame-parameter nil 'background-color "yellow")
;; => background has been changed to yellow and titlebar remained in original color
(set-frame-parameter nil 'mac-transparent-titlebar t)
;; => titlebar color has changed to yellow
(set-frame-parameter nil 'mac-transparent-titlebar nil)
;; => titlebar color has changed to original one
```

fixes: #83