### PR TITLE
Automatically treat high-DPI images as doubled

### DIFF
--- a/README-mac
+++ b/README-mac
@@ -185,16 +185,20 @@ the following Mac-specific ones:
     swiping/flicking, exiting from the splash screen by typing "q",
     and the "About Emacs" and "Preferences..." menu items in the
     application menu (labeled "Emacs") in the menu bar.
-  * High-resolution image display support for Retina displays.
-    Dynamic resolution change is also supported.  For bitmap formats,
-    high-resolution data can be specified either by the "@2x" file
-    name convention, the ":data-2x" property, or multi-image TIFF.
-    Shrinking a large image with the "imagemagick" (or Mac-specific
-    "image-io") image type also works but gives a non-optimal result
-    on dynamic resolution change.  For vector formats, images are
-    automatically re-rendered according to the resolution of the
-    frame.  DocView mode and LaTeX fragment preview in Org mode are
-    modified so they can take advantage of this feature.
+
+  * High-resolution image display support for Retina displays.  Dynamic
+    resolution change is also supported.  For bitmap formats,
+    high-resolution data can be specified either by the "@2x" file name
+    convention, the ":data-2x" property, or multi-image TIFF.
+    Additionally, if the DPI metadata in an image without any of these
+    properties indicates that it is a high-resolution image, it will
+    automatically be treated as a "2x" image.  Shrinking a large image
+    with the "imagemagick" (or Mac-specific "image-io") image type also
+    works but gives a non-optimal result on dynamic resolution change.
+    For vector formats, images are automatically re-rendered according
+    to the resolution of the display the frame in on.  DocView mode and
+    LaTeX fragment preview in Org mode are modified so they can take
+    advantage of this feature.
 
 As Quickdraw-style font rendering is considered obsolete as of Mac OS
 X 10.5, the variable `mac-allow-anti-aliasing', which was supported in

--- a/src/image.c
+++ b/src/image.c
@@ -5220,6 +5220,23 @@ image_load_image_io (struct frame *f, struct image *img, CFStringRef type)
 
 		  if (cg_image)
 		    {
+		      CFNumberRef dpi_width_ref = CFDictionaryGetValue (props, kCGImagePropertyDPIWidth);
+		      CFNumberRef dpi_height_ref = CFDictionaryGetValue (props, kCGImagePropertyDPIHeight);
+
+		      /* Auto-detect high-DPI 2x images */
+		      if (img->target_backing_scale == 0 && (dpi_width_ref || dpi_height_ref))
+			{
+			  double dpi_width = 72.0, dpi_height = 72.0;
+
+			  if (dpi_width_ref)
+			    CFNumberGetValue (dpi_width_ref, kCFNumberDoubleType, &dpi_width);
+			  if (dpi_height_ref)
+			    CFNumberGetValue (dpi_height_ref, kCFNumberDoubleType, &dpi_height);
+
+			  double max_dpi = fmax(dpi_width, dpi_height);
+			  if (max_dpi > 115.0) /* High DPI */
+			    img->target_backing_scale = 2;
+			}
 		      width = CGImageGetWidth (cg_image);
 		      height = CGImageGetHeight (cg_image);
 		      if (img->target_backing_scale == 2)


### PR DESCRIPTION
A problem can easily be seen by include a screenshot taken from a Retina display as an inline image (e.g. in `org-mode`): the size of the image is doubled.  That's because it is a 2x image, which should be displayed on retina displays pixel-for-pixel (not "doubled" in size).  The nominal way to do this is to set `:data-2x` property or name the file with `@2x`, but that puts the burden on the _user_.  This patch looks at the published DPI in the file (if any) and treats it as a "2x" high-DPI file if it exceeds some threshold.

* src/image.c (image_load_image_io): Check the maximum DPI in an image,
and if above 115dpi, set the images target_backing_scale=2 (pixel
doubled).
* README-mac: Document.

Please test with your setup.  E.g. use `media-yank` with retina screenshots on standard and high-DPI displays.  Images should look "normal size".