### PR TITLE
Allow starting Emacs app from src/emacs

### DIFF
--- a/src/macappkit.m
+++ b/src/macappkit.m
@@ -1954,6 +1954,25 @@ emacs_windows_need_display_p (void)
 
 @end				// EmacsController
 
+void
+init_activation_policy (void)
+{
+  mac_within_gui (^{
+    if ([NSApp activationPolicy] == NSApplicationActivationPolicyProhibited)
+      {
+	/* Set the app's activation policy to regular when we run
+	   outside of a bundle.  This is already done for us by
+	   Info.plist when we run inside a bundle.  */
+	[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+
+	const char *file = "mac/Emacs.app/Contents/Resources/Emacs.icns";
+	NSString *path
+	  = [NSString stringWithFormat:@"%s/../%s", SDATA (Vdata_directory), file];
+	NSImage *image = [[NSImage alloc] initByReferencingFile:path];
+	[NSApp setApplicationIconImage:image];
+      }});
+}
+
 OSStatus
 install_application_handler (void)
 {

--- a/src/macterm.c
+++ b/src/macterm.c
@@ -5858,6 +5858,8 @@ mac_initialize (void)
 
   record_startup_key_modifiers ();
 
+  init_activation_policy ();
+
   unblock_input ();
 }
 

--- a/src/macterm.h
+++ b/src/macterm.h
@@ -616,6 +616,7 @@ extern CFStringRef mac_uti_create_with_mime_type (CFStringRef);
 extern CFStringRef mac_uti_create_with_filename_extension (CFStringRef);
 extern CFStringRef mac_uti_copy_filename_extension (CFStringRef);
 extern CFStringRef mac_uti_copy_mime_type (CFStringRef);
+extern void init_activation_policy (void);
 extern OSStatus install_application_handler (void);
 extern Lisp_Object mac_application_state (void);
 extern void mac_set_frame_window_title (struct frame *, CFStringRef);


### PR DESCRIPTION
* src/macappkit.m (install_application_handler): New function.
* src/macterm.h: Declare it.
* src/macterm.c (mac_initialize): Call it.

As proposed by @gerd-moellmann in #50.

With this, you can start the "raw" just-built `src/emacs` executable and
it will function as a full app, without needing to `make install`.