### PR TITLE
Disable NSAutoFillHeuristicController

### DIFF
--- a/src/macappkit.m
+++ b/src/macappkit.m
@@ -6451,6 +6451,8 @@ static BOOL emacsViewUpdateLayerDisabled;
     {
       NSUserDefaults *defaults = NSUserDefaults.standardUserDefaults;
 
+      if ([defaults objectForKey:@"NSAutoFillHeuristicControllerEnabled"] == nil)
+	[defaults registerDefaults:@{@"NSAutoFillHeuristicControllerEnabled" : @false}];
       if ([defaults objectForKey:@"ApplePressAndHoldEnabled"] == nil)
 	[defaults registerDefaults:@{@"ApplePressAndHoldEnabled" : @"NO"}];
     }

--- a/src/macappkit.m
+++ b/src/macappkit.m
@@ -6452,7 +6452,7 @@ static BOOL emacsViewUpdateLayerDisabled;
       NSUserDefaults *defaults = NSUserDefaults.standardUserDefaults;
 
       if ([defaults objectForKey:@"NSAutoFillHeuristicControllerEnabled"] == nil)
-	[defaults registerDefaults:@{@"NSAutoFillHeuristicControllerEnabled" : @false}];
+	[defaults registerDefaults:@{@"NSAutoFillHeuristicControllerEnabled" : @"NO"}];
       if ([defaults objectForKey:@"ApplePressAndHoldEnabled"] == nil)
 	[defaults registerDefaults:@{@"ApplePressAndHoldEnabled" : @"NO"}];
     }


### PR DESCRIPTION
MacOS 26 is bugged in that applications become progressively slower at handling events over time, this is due to some behavior by NSAutoFillHeuristicController.

See https://github.com/ghostty-org/ghostty/pull/8625 for further information.