### PR TITLE
Fix interactions between transparent title bar and native tab bar

### DIFF
--- a/doc/emacs/macport.texi
+++ b/doc/emacs/macport.texi
@@ -540,11 +540,36 @@ title/tool/tab bars look slightly colored with the value of the
 color) if the frame is focused and not in fullscreen.
 
 @vindex mac-transparent-titlebar
- The title bar transparency can be controlled by the value of the
+  The title bar transparency can be controlled by the value of the
 @code{mac-transparent-titlebar} frame parameter.  If it is @code{nil},
 which is the default then title bar uses system color for its
 background.  If it is non-@code{nil} then the frame background color is
 used instead.
+
+It is recommended that the theme applied on the frame with transparent
+title bar matches current macOS appearance.  That is, when macOS
+appearance is Light the theme should have a light colored background.
+Likewise, when macOS appearance is Dark the theme should have a dark
+colored background.
+
+The theme can be automatically changed when macOS appearance changes by
+registering a @code{mac-effective-appearance-change-hook}, for example:
+
+@example
+(add-hook
+ 'mac-effective-appearance-change-hook
+ (lambda ()
+   "Switch theme according to current system setting."
+   (when-let* ((appearance (plist-get (mac-application-state)
+                                      :appearance))
+               (desired-theme (let ((case-fold-search t))
+                                (if (string-match-p "dark" appearance)
+                                    (cadr modus-themes-to-toggle)
+                                  (car modus-themes-to-toggle))))
+               ((not (eq desired-theme
+                         (car custom-enabled-themes)))))
+     (message "Loading theme: %s" desired-theme))))
+@end example
 
 @node Mac Fullscreen
 @section Fullscreen support on the Mac Port

--- a/src/macappkit.m
+++ b/src/macappkit.m
@@ -2594,7 +2594,7 @@ static void mac_move_frame_window_structure_1 (struct frame *, int, int);
   MRC_RELEASE (visualEffectView);
 
   if ([window respondsToSelector:@selector(titlebarAppearsTransparent)])
-    [window setTitlebarAppearsTransparent:FRAME_MAC_TRANSPARENT_TITLEBAR(f)];
+    [window setTitlebarAppearsTransparent:FRAME_MAC_TRANSPARENT_TITLEBAR(f) ? YES : NO];
 
   FRAME_BACKGROUND_ALPHA_ENABLED_P (f) = true;
   if (FRAME_MAC_DOUBLE_BUFFERED_P (f))
@@ -4322,7 +4322,7 @@ mac_set_frame_window_transparent_titlebar (struct frame *f, bool transparent)
 
   mac_within_gui (^{
       if ([window respondsToSelector: @selector(titlebarAppearsTransparent)])
-	[window setTitlebarAppearsTransparent:transparent];});
+	[window setTitlebarAppearsTransparent:transparent ? YES : NO];});
 }
 
 void

--- a/src/macappkit.m
+++ b/src/macappkit.m
@@ -2593,9 +2593,6 @@ static void mac_move_frame_window_structure_1 (struct frame *, int, int);
   window.contentView = visualEffectView;
   MRC_RELEASE (visualEffectView);
 
-  if ([window respondsToSelector:@selector(titlebarAppearsTransparent)])
-    [window setTitlebarAppearsTransparent:FRAME_MAC_TRANSPARENT_TITLEBAR(f) ? YES : NO];
-
   FRAME_BACKGROUND_ALPHA_ENABLED_P (f) = true;
   if (FRAME_MAC_DOUBLE_BUFFERED_P (f))
     {
@@ -2670,6 +2667,11 @@ static void mac_move_frame_window_structure_1 (struct frame *, int, int);
 	  && !FRAME_PARENT_FRAME (f))
 	window.collectionBehavior = NSWindowCollectionBehaviorFullScreenPrimary;
       window.animationBehavior = NSWindowAnimationBehaviorDocumentWindow;
+      if ([window respondsToSelector:@selector(titlebarAppearsTransparent)])
+	{
+	  BOOL transparent = FRAME_MAC_TRANSPARENT_TITLEBAR(f) ? YES : NO;
+	  [window setTitlebarAppearsTransparent:transparent];
+	}
     }
   else
     {

--- a/src/macappkit.m
+++ b/src/macappkit.m
@@ -1232,7 +1232,7 @@ static bool handling_queued_nsevents_p;
        selector:@selector(willSleep:)
 	   name:NSWorkspaceWillSleepNotification
 	 object:nil];
-  
+
   [NSApp registerUserInterfaceItemSearchHandler:self];
   Vmac_help_topics = Qnil;
 
@@ -2022,6 +2022,24 @@ mac_application_state (void)
 static void set_global_focus_view_frame (struct frame *);
 static void unset_global_focus_view_frame (void);
 static void mac_move_frame_window_structure_1 (struct frame *, int, int);
+static void
+mac_with_suppressed_transparent_titlebar( NSWindow* window, BOOL assumeTransparent, void (CF_NOESCAPE ^block) (void))
+{
+  BOOL isTransparent = assumeTransparent ||
+    ([window respondsToSelector:@selector(titlebarAppearsTransparent)] &&
+     [window titlebarAppearsTransparent]);
+  if (isTransparent)
+    [window setTitlebarAppearsTransparent:NO];
+  @try
+    {
+      block ();
+    }
+  @finally
+    {
+      if (isTransparent)
+	[window setTitlebarAppearsTransparent:YES];
+    }
+}
 
 #define DEFAULT_NUM_COLS (80)
 #define RESIZE_CONTROL_WIDTH (15)
@@ -2379,6 +2397,32 @@ static void mac_move_frame_window_structure_1 (struct frame *, int, int);
     return self.contentView;
   else
     return self;
+}
+
+- (NSWindowTabGroup *)tabGroup
+{
+  __block NSWindowTabGroup *tg = [super tabGroup];
+  if (tg)
+    return tg;
+  /* On a newly created Emacs window, that has a transparent title bar
+     (e.g., as a result of (mac-transparent-titlebar . t) being present
+     in default-frame-alist, or when the transparency has been turned on
+     for a window before tabGroup has been called for the window) the
+     call to super class' -[NSWindow tabGroup] yields NULL.  The
+     workaround is to disable the transparency temporarily then call the
+     super class again.  Strangely enough, subsequent calls to
+     -[NSWindow tabGroup] (made from such a window with transparent
+     title bar) yield a proper NSWindowTabGroup object.  */
+  else if ([self respondsToSelector:@selector(titlebarAppearsTransparent)] &&
+	   [self titlebarAppearsTransparent])
+    {
+      mac_with_suppressed_transparent_titlebar (self, YES, ^{
+	  tg = [super tabGroup];
+	});
+      return tg;
+    }
+  else
+    return NULL;
 }
 
 @end				// EmacsWindow
@@ -4655,9 +4699,14 @@ mac_set_tab_group_overview_visible_p (struct frame *f, Lisp_Object value)
   mac_within_app (^{
       if (window.tabGroup.isOverviewVisible != !NILP (value))
 	{
-	  /* Just setting the property window.tabGroup.overviewVisible
-	     does not show the search field on macOS 10.13 Beta.  */
-	  [NSApp sendAction:@selector(toggleTabOverview:) to:window from:nil];
+	  /* Sending toggleTabOverview to window doesn't work when the
+	     window has a transparent title bar.  Suppress the
+	     transparency temporarily for the call.  */
+	  mac_with_suppressed_transparent_titlebar (window, NO, ^{
+	      /* Just setting the property window.tabGroup.overviewVisible
+		 does not show the search field on macOS 10.13 Beta.  */
+	      [NSApp sendAction:@selector(toggleTabOverview:) to:window from:nil];
+	    });
 	  result = Qt;
 	}
     });
@@ -4680,12 +4729,17 @@ mac_set_tab_group_tab_bar_visible_p (struct frame *f, Lisp_Object value)
 	result = build_string ("Tab bar cannot be made invisible because of multiple tabs");
       else
 	{
-	  [window exitTabGroupOverview];
-	  [NSApp sendAction:@selector(toggleTabBar:) to:window from:nil];
-	  [[NSUserDefaults standardUserDefaults]
-	    removeObjectForKey:[@"NSWindowTabbingShoudShowTabBarKey-"
-				   stringByAppendingString:window.tabbingIdentifier]];
-	  result = Qt;
+	      [window exitTabGroupOverview];
+	      /* Sending toggleTabBar doesn't work when the window has a
+		 transparent title bar.  Suppress the transparency
+		 temporarily for the call.  */
+	      mac_with_suppressed_transparent_titlebar (window, NO, ^{
+		  [NSApp sendAction:@selector(toggleTabBar:) to:window from:nil];
+		});
+	      [[NSUserDefaults standardUserDefaults]
+		removeObjectForKey:[@"NSWindowTabbingShoudShowTabBarKey-"
+				       stringByAppendingString:window.tabbingIdentifier]];
+	      result = Qt;
 	}
     });
 

--- a/src/macfns.c
+++ b/src/macfns.c
@@ -2536,6 +2536,9 @@ DEFUN ("x-create-frame", Fx_create_frame, Sx_create_frame,
                          "alpha", "Alpha", RES_TYPE_NUMBER);
   gui_default_parameter (f, parms, Qalpha_background, Qnil,
                          "alphaBackground", "AlphaBackground", RES_TYPE_NUMBER);
+  gui_default_parameter (f, parms, Qborders_respect_alpha_background, Qnil,
+                         "bordersRespectAlphaBackground",
+                         "BordersRespectAlphaBackground", RES_TYPE_NUMBER);
 
   mac_default_scroll_bar_color_parameter (f, parms, Qscroll_bar_foreground,
 					  "scrollBarForeground",
@@ -5264,6 +5267,7 @@ frame_parm_handler mac_frame_parm_handlers[] =
   mac_set_override_redirect,
   gui_set_no_special_glyphs,
   gui_set_alpha_background,
+  gui_set_borders_respect_alpha_background,
   NULL, /* mac_set_use_frame_synchronization */
   /* Skipping the following parameters from frame_parms that are not
      compiled when HAVE_MACGUI is defined:

--- a/test/src/mac-transparent-titlebar-tab-bar-tests.el
+++ b/test/src/mac-transparent-titlebar-tab-bar-tests.el
@@ -1,0 +1,163 @@
+;;; mac-transparent-titlebar-tab-bar-tests.el --- Tests for interactions between tranparent title bar and native tab-bar -*- lexical-binding:t -*-
+
+;;; Commentary:
+;;
+;; This tests are designed to run with a visible frame (a GUI window),
+;; as they verify native macOS tab-bar functionality while
+;; `mac-transparent-titlebar' is enabled.  As such there's not
+;; implemeted as ert style tests per se, i.e. not a series of
+;; `deftest's, but rather this file should be evaled as a script, e.g.,
+;;
+;;   emacs -Q -load mac-transparent-titlebar-tab-bar-tests.el
+
+;;; Code:
+
+(require 'ert)
+
+(defun wait-for (secs)
+  "Wait for SECS and force redisplaying the window."
+  (let ((until (+ (float-time) secs))
+        (interval (/ secs 20.0)))
+    (while (< (float-time) until)
+      (sleep-for interval)
+      (force-window-update)
+      (redisplay))))
+
+;; Need some time for the frame to be fully drawn in the screen.
+(wait-for 5)
+
+(setq debug-on-error t)
+
+(defvar frame-stack nil)
+
+;; (0) Enable transparency on current frame and all new frames
+(set-frame-parameter nil 'mac-transparent-titlebar t)
+(add-to-list 'default-frame-alist '(mac-transparent-titlebar . t))
+
+;; (1) Test the initial frame
+(push (should
+       (mac-frame-tab-group-property nil :selected-frame))
+      frame-stack)
+(should (frame-parameter nil 'mac-transparent-titlebar))
+(should (eql 1
+             (length (mac-frame-tab-group-property nil :frames))))
+(should-not (mac-frame-tab-group-property nil :tab-bar-visible-p))
+(should-not (mac-frame-tab-group-property nil :overview-visible-p))
+
+;; toggle tab-bar on and off
+(mac-set-frame-tab-group-property nil :tab-bar-visible-p t)
+(should (mac-frame-tab-group-property nil :tab-bar-visible-p))
+(mac-set-frame-tab-group-property nil :tab-bar-visible-p nil)
+(should-not (mac-frame-tab-group-property nil :tab-bar-visible-p))
+
+;; TODO: need to find a way to exit overview programatically
+;; ;; toggle overview on and off
+;; (mac-set-frame-tab-group-property nil :tab-bar-visible-p t)
+;; (should (mac-frame-tab-group-property nil :tab-bar-visible-p))
+;; (should
+;;  (progn
+;;    (mac-set-frame-tab-group-property nil :overview-visible-p t)
+;;    (mac-frame-tab-group-property nil :overview-visible-p)))
+;; ;; when one tab is present tab-bar is hidden after exiting overview
+;; (should-not (mac-frame-tab-group-property nil :tab-bar-visible-p))
+
+;; (2) Open a new frame in a new tab and test it
+(mac-set-frame-tab-group-property nil :tab-bar-visible-p t)
+(should (mac-frame-tab-group-property nil :tab-bar-visible-p))
+;; Need some time for tab bar to be drawn in the screen
+(wait-for 2)
+(mac-handle-new-window-for-tab nil)
+;; Need some time for the new fame to be drawn in the screen
+(wait-for 2)
+
+(push (should
+       (mac-frame-tab-group-property nil :selected-frame))
+      frame-stack)
+;; the :selecte-frame is a truly unique frame
+(should-not (equal (car frame-stack) (cadr frame-stack)))
+(let ((frames (mac-frame-tab-group-property nil :frames)))
+  (should (eql 2 (length frames)))
+  (should (member (car frame-stack) frames))
+  (should (member (cadr frame-stack) frames)))
+
+(should (frame-parameter nil 'mac-transparent-titlebar))
+(should-not (mac-frame-tab-group-property nil :overview-visible-p))
+
+;; tab-bar cannot be swiched off when there's more than one tab
+(should-error (mac-set-frame-tab-group-property nil :tab-bar-visible-p nil))
+(should (mac-frame-tab-group-property nil :tab-bar-visible-p))
+
+;; TODO: need to find a way to exit overview programatically
+;; ;; toggle overview on and off
+;; (should (mac-frame-tab-group-property nil :tab-bar-visible-p))
+;; (should-not (mac-frame-tab-group-property nil :overview-visible-p))
+;; (should
+;;  (progn
+;;    (mac-set-frame-tab-group-property nil :overview-visible-p t)
+;;    (mac-frame-tab-group-property nil :overview-visible-p)))
+;; ;; tab-bar is visible after exiting overview when there's more than one tab-bar
+;; (should (mac-frame-tab-group-property nil :tab-bar-visible-p))
+
+
+;; select previously selected frame
+(mac-set-frame-tab-group-property nil :selected-frame (cadr frame-stack))
+(should (equal (cadr frame-stack)
+               (mac-frame-tab-group-property nil :selected-frame)))
+
+;; (3) Open a new frame in a new window and test it
+(let ((f (make-frame)))
+  (select-frame f))
+
+(push (should
+       (mac-frame-tab-group-property nil :selected-frame))
+      frame-stack)
+;; the :selecte-frame is a truly unique frame
+(should (eql 3 (length frame-stack)))
+(should-not (equal (car frame-stack) (cadr frame-stack)))
+(should-not (equal (car frame-stack) (caddr frame-stack)))
+
+(let ((frames (mac-frame-tab-group-property nil :frames)))
+  (should (eql 1 (length frames)))
+  (should (member (car frame-stack) frames)))
+
+(should (frame-parameter nil 'mac-transparent-titlebar))
+(should-not (mac-frame-tab-group-property nil :overview-visible-p))
+(should-not (mac-frame-tab-group-property nil :tab-bar-visible-p))
+
+;; toggle tab-bar on and off
+(mac-set-frame-tab-group-property nil :tab-bar-visible-p t)
+(should (mac-frame-tab-group-property nil :tab-bar-visible-p))
+(mac-set-frame-tab-group-property nil :tab-bar-visible-p nil)
+(should-not (mac-frame-tab-group-property nil :tab-bar-visible-p))
+
+;; (4) Transfer one frame from the first window to the newly opened window
+(mac-set-frame-tab-group-property
+ nil :frames
+ (list (car frame-stack)
+       (cadr frame-stack)))
+
+(let ((frames (mac-frame-tab-group-property nil :frames)))
+  (should (eql 2 (length frames)))
+  (should (member (car frame-stack) frames))
+  (should (member (cadr frame-stack) frames)))
+(should (mac-frame-tab-group-property nil :tab-bar-visible-p))
+
+(let* ((f (caddr frame-stack))
+       (frames (mac-frame-tab-group-property f :frames)))
+  (should (eql 1 (length frames)))
+  (should (member f frames))
+  (should-not (mac-frame-tab-group-property f :tab-bar-visible-p)))
+
+
+;; (5) Test the overview visible
+(should
+ (progn
+   (mac-set-frame-tab-group-property nil :overview-visible-p t)
+   (mac-frame-tab-group-property nil :overview-visible-p)))
+
+;; All done - test pass!
+(kill-emacs 0)
+
+(provide 'mac-transparent-titlebar-tab-bar-tests)
+
+;;; mac-transparent-titlebar-tab-bar-tests.el ends here


### PR DESCRIPTION
This fixes interactions between transparent title bar (a frame with a
non-nil parameter `mac-transparent-tiltebar`) and macOS native tab bar
(setting mac frame tab group properties `:tab-bar-visible-p`
and `:overview-visible-p`).  It is achieved by temporarily disabling
title bar transparency when interacting with `NSWindow`'s functions
related to tab bar.

There's also a few other fixes and improvements:
* Ensure the frame parameter `borders-respect-alpha-background` is
  respected.  The parameter has been introduced in Emacs 31 and there
  was no handler for it in Emacs mac.  I copied the solution, from
  whatever NS port does (just set the parameter value in the frame
  model).
* Avoid setting transparent title bar for tooltip frames.
* Use `YES` and `NO` values for functions that take `BOOL` arguments.
* Update documentation to explicitly note that when transparent title
  bar is used, the frame background should match macOS appearance (light
  or dark).
* Added tests focusing on interactions between transparent title bar and
  native tab bar.

I have tested this change on macOS Sequoia 15.6.1 (M2) and macOS Big Sur
11.7.10 (Intel).

Fixes: #104