### PR TITLE
Fix GCD deadlock on sync queue draw

### DIFF
--- a/src/macappkit.m
+++ b/src/macappkit.m
@@ -7630,6 +7630,7 @@ static CGContextRef saved_focus_view_context;
 static bool saved_focus_view_modified_p;
 #if DRAWING_USE_GCD
 static dispatch_queue_t global_focus_drawing_queue;
+static const void * kDrawingQueueKey = &kDrawingQueueKey;
 #endif
 
 static void
@@ -7651,8 +7652,12 @@ set_global_focus_view_frame (struct frame *f)
   if (mac_drawing_use_gcd)
     {
       if (global_focus_drawing_queue == NULL)
-	global_focus_drawing_queue =
-	  dispatch_queue_create ("org.gnu.Emacs.drawing", NULL);
+        {
+          global_focus_drawing_queue =
+            dispatch_queue_create ("org.gnu.Emacs.drawing", NULL);
+          dispatch_queue_set_specific(global_focus_drawing_queue, kDrawingQueueKey,
+                                      (void *)kDrawingQueueKey, NULL);
+        }
     }
   else
     {
@@ -7671,8 +7676,10 @@ static void
 mac_draw_queue_sync (void)
 {
 #if DRAWING_USE_GCD
-  if (global_focus_drawing_queue)
-    dispatch_sync (global_focus_drawing_queue, ^{});
+  if (global_focus_drawing_queue &&
+      /* Avoid deadlock if already on the drawing queue */
+      !dispatch_get_specific(kDrawingQueueKey))
+      dispatch_sync (global_focus_drawing_queue, ^{});
 #endif
 }
 


### PR DESCRIPTION
**TLDR:** A queue attempting to flush itself from the "inside" with a call to `dispatch_sync` deadlocks, so don't do that.

Another attempt to fix the dreaded (but rare) GCD draw deadlock, that often (but not always) occurs on waking from sleep.  See #78.  

Here we assume the problem arises from a serial queue deadlock which occurs when a block from the queue running on the main GUI thread attempts to use `dispatch_sync` on the same queue.

So an asynchronous block on the `global_focus_drawing_queue` tries to "flush" the queue, using `dispatch_sync` to quickly wait for it to complete all its submitted blocks.  But if this happens on the main thread, `dispatch_sync` is waiting for the queue to drain, and the currently executing block on the selfsame queue is waiting for `dispatch_sync` to complete: deadlock!  

Apparently this isn't a modern approach to drain GCD queues, but I kept it intact, and simply do nothing to sync if we are calling in to the same queue.

See also #86 for another (failed) attempt.

* src/macappkit.m (set_global_focus_view_frame): set identifier key on
drawing queue for easy identification.
(mac_draw_queue_sync): Do not dispatch empty block if already running
from drawing queue.