### PR TITLE
Fix setting of window appearance

### DIFF
--- a/src/macappkit.m
+++ b/src/macappkit.m
@@ -2623,6 +2623,8 @@ static void mac_move_frame_window_structure_1 (struct frame *, int, int);
 	  }
       window.appearanceCustomization.appearance =
 	oldWindow.appearanceCustomization.appearance;
+      window.appearance =
+	oldWindow.appearance;
 
       [oldWindow setDelegate:nil];
       [self hideHourglass:nil];
@@ -5260,6 +5262,8 @@ mac_set_frame_window_background (struct frame *f, unsigned long color)
 	 ? NSAppearanceNameVibrantLight : NSAppearanceNameVibrantDark);
 
       window.appearanceCustomization.appearance =
+	[NSAppearance appearanceNamed:name];
+      window.appearance =
 	[NSAppearance appearanceNamed:name];
     });
 }


### PR DESCRIPTION
This PR makes the window appearance correctly change based on the background colour of the frame: when a theme with a light background is loaded, the window appearance changes to 'light', and likewise with themes with dark backgrounds.

When the titlebar is not transparent, the effect is as with changing the system between light and dark mode, so perhaps this isn't an ideal 'fix' as people might have been relying on the title bar appearance always reflecting their system choice?

When the titlebar is transparent, this makes text legible when a light theme is used and the system is in dark mode:

Before: 
<img width="831" height="802" alt="Screenshot 2025-11-01 at 14 58 40" src="https://github.com/user-attachments/assets/51334e42-9364-40bc-93fb-b27dd89f360f" />

After:
<img width="705" height="754" alt="Screenshot 2025-11-01 at 15 01 37" src="https://github.com/user-attachments/assets/1d7eaf2d-6039-459a-8632-249390221ba8" />


I'm not sure why this is needed, perhaps macos changed the source of truth for this parameter, or it was always broken.