### PR TITLE
Add unlimited select flags to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ A _self-contained_ app by default will go into `/Applications/Emacs.app`.
 CFLAGS="-O2 -mcpu=native" ./configure --with-native-compilation --with-tree-sitter --enable-mac-app=yes --enable-mac-self-contained
 ```
 
+Optionally, you can add `-DFD_SETSIZE=10000 -D_DARWIN_UNLIMITED_SELECT` to `CFLAGS` to increase the file descriptor limit, to help with packages that open many connections (like LSP).
+Note that this may degrade performance in some cases.
+
 You can specify another build directory for the self-contained app using `--enable-mac-app=/path/to/dir`.
 
 >[!NOTE]


### PR DESCRIPTION
Adds two new flags to CFLAGS in order to increse the maximum number of file descriptions emacs can support. This is important if you use several projects with lsp.

Source: https://en.liujiacai.net/2022/09/03/emacs-maxopenfiles/
[Emacs-plus](https://github.com/d12frosted/homebrew-emacs-plus) does the [same](https://github.com/d12frosted/homebrew-emacs-plus/blob/8c811e9931a213d78baa8e443244d31b7c8771c3/Formula/emacs-plus%4030.rb#L126C51-L126C75).
