### PR TITLE
Add mac-appearance frame parameter

### DIFF
--- a/doc/emacs/macport.texi
+++ b/doc/emacs/macport.texi
@@ -529,31 +529,51 @@ defaults write org.gnu.Emacs Emacs.fringe.attributeStipple alpha:.5
 @code{scroll-bar-background} frame parameter.  If it is @code{nil},
 which is the default, then the frame background color is used instead.
 Its color also affects the appearance of other GUI parts: scroll bars,
-the title bar, the tool bar, (the tab bar on macOS 10.12 and later),
-and popup menus on OS X 10.10 -- macOS 10.13 become light (or dark) if
-the color is considered light (or dark, respectively).  On macOS 10.14
-and later, the appearance of GUI parts other than scroll bars respect
-the global setting, which is available via
+the title bar, the tool bar, (the tab bar on macOS 10.12 and later), and
+popup menus on OS X 10.10 -- macOS 10.13 become light (or dark) if the
+color is considered light (or dark, respectively).  Unless
+@code{mac-appearance} frame parameter is non-@code{nil}, then on macOS
+10.14 and later, the appearance of GUI parts other than scroll bars
+respect the global setting, which is available via the function
 @code{(mac-application-state)}.  On macOS 10.12 and later, the
 title/tool/tab bars look slightly colored with the value of the
 @code{scroll-bar-background} frame parameter (or the frame background
 color) if the frame is focused and not in fullscreen.
 
-@vindex mac-transparent-titlebar
-  The title bar transparency can be controlled by the value of the
-@code{mac-transparent-titlebar} frame parameter.  If it is @code{nil},
-which is the default then title bar uses system color for its
-background.  If it is non-@code{nil} then the frame background color is
-used instead.
+@vindex mac-appearance@r{, a frame parameter}
+  If set to @code{dark} draw this frame's window-system window using the
+``vibrant dark'' theme.  If set to @code{light} draw this frame's
+window-system window using ``vibrant light'' theme.  Otherwise, when set
+to @code{nil} (which is the default) use an automatic appearance based
+on the frame's background color.  When the automatic appearance doesn't
+render a legible frame, the ``vibrant dark'' theme/``vibrant light''
+theme can be used to set the toolbar and scrollbars to a macOS
+Dark/Light appearance when using an Emacs theme with a dark/light
+background.  For example to make Emacs frame appearance to follow system
+appearance the following snipped can be used:
 
-It is recommended that the theme applied on the frame with transparent
-title bar matches current macOS appearance.  That is, when macOS
-appearance is Light the theme should have a light colored background.
-Likewise, when macOS appearance is Dark the theme should have a dark
-colored background.
+@example
+(add-hook
+ 'mac-effective-appearance-change-hook
+ (lambda ()
+   "Change frames appearances according to current system setting."
+   (when-let* ((system-appearance (plist-get (mac-application-state)
+                                             :appearance))
+               (appearance (if (let ((case-fold-search t))
+                                 (string-match "dark" system-appearance))
+                               'dark
+                             'light)))
+     (dolist (frame (frame-list))
+       (unless (eq (frame-parameter frame 'mac-appearance)
+                   appearance)
+         (set-frame-parameter frame 'mac-appearance appearance))))))
+@end example
 
-The theme can be automatically changed when macOS appearance changes by
-registering a @code{mac-effective-appearance-change-hook}, for example:
+  In cases when theme change occurs as a result of system appearance
+change, the automatic frame appearance - based on the theme's background
+may be sufficient.  The theme can be automatically changed when macOS
+appearance changes by registering a
+@code{mac-effective-appearance-change-hook}, for example:
 
 @example
 (add-hook
@@ -563,13 +583,30 @@ registering a @code{mac-effective-appearance-change-hook}, for example:
    (when-let* ((appearance (plist-get (mac-application-state)
                                       :appearance))
                (desired-theme (let ((case-fold-search t))
-                                (if (string-match-p "dark" appearance)
+                                (if (string-match "dark" appearance)
                                     (cadr modus-themes-to-toggle)
                                   (car modus-themes-to-toggle))))
                ((not (eq desired-theme
                          (car custom-enabled-themes)))))
-     (message "Loading theme: %s" desired-theme))))
+     (message "Loading theme: %s" desired-theme)
+     (load-theme desired-theme))))
 @end example
+
+@vindex mac-transparent-titlebar@r{, a frame parameter}
+  The title bar transparency can be controlled by the value of the
+@code{mac-transparent-titlebar} frame parameter.  If it is @code{nil},
+which is the default then title bar uses system color for its
+background.  If it is non-@code{nil} then the frame background color is
+used instead.
+
+  It is recommended that theme applied on a frame with transparent title
+bar matches current macOS appearance (as reported by
+@code{mac-application-state}) when frame parameter
+@code{mac-appearance} is @code{nil} or value of frame parameter
+@code{mac-appearance} when it is non-@code{nil}.  That is, when the
+appearance is Light the theme should have a light colored background.
+Likewise, when the appearance is Dark the theme should have a dark
+colored background.
 
 @node Mac Fullscreen
 @section Fullscreen support on the Mac Port

--- a/src/frame.c
+++ b/src/frame.c
@@ -1215,6 +1215,7 @@ make_frame (bool mini_p)
   f->ns_transparent_titlebar = false;
 #endif
 #ifdef HAVE_MACGUI
+  f->mac_appearance = mac_appearance_system_default;
   f->mac_transparent_titlebar = false;
 #endif
 #endif
@@ -4886,6 +4887,7 @@ static const struct frame_parm_table frame_parms[] =
   {"ns-transparent-titlebar",	SYMBOL_INDEX (Qns_transparent_titlebar)},
 #endif
 #ifdef HAVE_MACGUI
+  {"mac-appearance",            SYMBOL_INDEX (Qmac_appearance)},
   {"mac-transparent-titlebar",  SYMBOL_INDEX (Qmac_transparent_titlebar)},
 #endif
 };
@@ -7332,6 +7334,7 @@ syms_of_frame (void)
   DEFSYM (Qns_transparent_titlebar, "ns-transparent-titlebar");
 #endif
 #ifdef HAVE_MACGUI
+  DEFSYM (Qmac_appearance, "mac-appearance");
   DEFSYM (Qmac_transparent_titlebar, "mac-transparent-titlebar");
 #endif
 

--- a/src/frame.h
+++ b/src/frame.h
@@ -77,6 +77,14 @@ enum ns_appearance_type
     ns_appearance_vibrant_dark
   };
 #endif
+#ifdef HAVE_MACGUI
+enum mac_appearance_type
+  {
+    mac_appearance_system_default,
+    mac_appearance_vibrant_light,
+    mac_appearance_vibrant_dark
+  };
+#endif
 #endif /* HAVE_WINDOW_SYSTEM */
 
 #ifdef HAVE_TEXT_CONVERSION
@@ -747,6 +755,7 @@ struct frame
   bool_bf ns_transparent_titlebar;
 #endif
 #ifdef HAVE_MACGUI
+  enum mac_appearance_type mac_appearance;
   bool_bf mac_transparent_titlebar;
 #endif
 

--- a/src/macappkit.m
+++ b/src/macappkit.m
@@ -4368,6 +4368,32 @@ mac_set_frame_window_modified (struct frame *f, bool modified)
   mac_within_gui (^{[window setDocumentEdited:modified];});
 }
 
+static NSAppearanceName
+automatic_appearance_from_color(unsigned long color)
+{
+  /* This formula comes from frame-set-background-mode in frame.el.  */
+  return (RED_FROM_ULONG (color) + GREEN_FROM_ULONG (color)
+	  + BLUE_FROM_ULONG (color)) >= (int) (0xff * 3 * .6)
+    ? NSAppearanceNameVibrantLight : NSAppearanceNameVibrantDark;
+}
+
+void
+mac_set_frame_window_appearance (struct frame *f, enum mac_appearance_type appearance)
+{
+  EmacsWindow *window = FRAME_MAC_WINDOW_OBJECT (f);
+
+  mac_within_gui (^{
+      NSAppearanceName name =
+	appearance == mac_appearance_system_default
+	? automatic_appearance_from_color (FRAME_BACKGROUND_PIXEL (f))
+	: (appearance == mac_appearance_vibrant_light
+	   ? NSAppearanceNameVibrantLight : NSAppearanceNameVibrantDark);
+      window.appearanceCustomization.appearance =
+	[NSAppearance appearanceNamed:name];
+      window.appearance =
+	[NSAppearance appearanceNamed:name];});
+}
+
 void
 mac_set_frame_window_transparent_titlebar (struct frame *f, bool transparent)
 {
@@ -5315,18 +5341,13 @@ mac_set_frame_window_background (struct frame *f, unsigned long color)
 
   mac_within_gui (^{
       [window setBackgroundColor:[NSColor colorWithEmacsColorPixel:color]];
-      /* This formula comes from frame-set-background-mode in
-	 frame.el.  */
-      NSAppearanceName name =
-	((RED_FROM_ULONG (color) + GREEN_FROM_ULONG (color)
-	  + BLUE_FROM_ULONG (color)) >= (int) (0xff * 3 * .6)
-	 ? NSAppearanceNameVibrantLight : NSAppearanceNameVibrantDark);
-
-      window.appearanceCustomization.appearance =
-	[NSAppearance appearanceNamed:name];
-      window.appearance =
-	[NSAppearance appearanceNamed:name];
-    });
+      if (FRAME_MAC_APPEARANCE (f) == mac_appearance_system_default)
+	{
+	  NSAppearanceName name = automatic_appearance_from_color (color);
+	  window.appearanceCustomization.appearance =
+	    [NSAppearance appearanceNamed:name];
+	  window.appearance =
+	    [NSAppearance appearanceNamed:name];}});
 }
 
 /* Store the screen positions of frame F into XPTR and YPTR.

--- a/src/macfns.c
+++ b/src/macfns.c
@@ -1215,6 +1215,36 @@ mac_set_override_redirect (struct frame *f, Lisp_Object new_value, Lisp_Object o
     }
 }
 
+static enum mac_appearance_type
+mac_set_appearance_1 (struct frame *f, Lisp_Object new_value)
+{
+  enum mac_appearance_type appearance = mac_appearance_system_default;
+  if (EQ (new_value, Qdark))
+    appearance = mac_appearance_vibrant_dark;
+  else if (EQ (new_value, Qlight))
+    appearance = mac_appearance_vibrant_light;
+
+  FRAME_MAC_APPEARANCE (f) = appearance;
+  return appearance;
+}
+
+static void
+mac_set_appearance (struct frame *f, Lisp_Object new_value, Lisp_Object old_value)
+{
+  if ((mac_operating_system_version.major < 10
+       || (mac_operating_system_version.major == 10
+	   && mac_operating_system_version.minor < 10)))
+    return;
+
+  if (!EQ (new_value, old_value))
+    {
+      enum mac_appearance_type appearance = mac_set_appearance_1 (f, new_value);
+      block_input ();
+      mac_set_frame_window_appearance (f, appearance);
+      unblock_input ();
+    }
+}
+
 static void
 mac_set_transparent_titlebar (struct frame *f, Lisp_Object new_value, Lisp_Object old_value)
 {
@@ -2546,6 +2576,12 @@ DEFUN ("x-create-frame", Fx_create_frame, Sx_create_frame,
   mac_default_scroll_bar_color_parameter (f, parms, Qscroll_bar_background,
 					  "scrollBarBackground",
 					  "ScrollBarBackground", false);
+
+  tem = gui_display_get_arg (dpyinfo, parms, Qmac_appearance,
+			     NULL, NULL, RES_TYPE_SYMBOL);
+  mac_set_appearance_1 (f, tem);
+  store_frame_param (f, Qmac_appearance,
+                     (!NILP (tem) && !EQ (tem, Qunbound)) ? tem : Qnil);
 
   tem = gui_display_get_arg (dpyinfo, parms, Qmac_transparent_titlebar,
 			     NULL, NULL, RES_TYPE_BOOLEAN);
@@ -5275,6 +5311,7 @@ frame_parm_handler mac_frame_parm_handlers[] =
      ns-appearance
      ns-transparent-titlebar
    */
+  mac_set_appearance,
   mac_set_transparent_titlebar,
 };
 
@@ -5314,6 +5351,8 @@ syms_of_macfns (void)
   DEFSYM (QCactive_p, ":active-p");
   DEFSYM (QChidden_p, ":hidden-p");
   DEFSYM (QCappearance, ":appearance");
+  DEFSYM (Qdark, "dark");
+  DEFSYM (Qlight, "light");
   DEFSYM (QCoverview_visible_p, ":overview-visible-p");
   DEFSYM (QCtab_bar_visible_p, ":tab-bar-visible-p");
   DEFSYM (QCselected_frame, ":selected-frame");

--- a/src/macterm.h
+++ b/src/macterm.h
@@ -339,6 +339,8 @@ struct mac_output
 #define FRAME_MAC_DOUBLE_BUFFERED_P(f) \
   ((f)->output_data.mac->double_buffered_p)
 
+#define FRAME_MAC_APPEARANCE(f) \
+  ((f)->mac_appearance)
 #define FRAME_MAC_TRANSPARENT_TITLEBAR(f) \
   ((f)->mac_transparent_titlebar)
 
@@ -623,6 +625,7 @@ extern OSStatus install_application_handler (void);
 extern Lisp_Object mac_application_state (void);
 extern void mac_set_frame_window_title (struct frame *, CFStringRef);
 extern void mac_set_frame_window_modified (struct frame *, bool);
+extern void mac_set_frame_window_appearance (struct frame *, enum mac_appearance_type);
 extern void mac_set_frame_window_transparent_titlebar (struct frame *, bool);
 extern void mac_set_frame_window_proxy (struct frame *, CFURLRef);
 extern bool mac_is_frame_window_visible (struct frame *);


### PR DESCRIPTION
This PR adds a new frame parameter `mac-appearance`.  It handles three
values:
* `nil` which means use automatic frame appearance based on current
  system appearance.
* `dark` which forces frame appearance to Vibrant Dark.
* `light` which forces frame appearance to Vibrant Light.

The concept of this parameter bases on `ns-appearance` frame
parameter. It uses Vibrant Light instead of Acqua for `light` setting,
as this is what Emacs-mac has always been doing.

Setting the value to non-`nil` forces the frame (window in macOS parlance) to use selected appearance (Vibrant Light or Vibrant Dark). It may be useful to use it when automatic appearance is not doing the right thing.


Setting the value to nil makes the frame to use automatic frame
appearance, based on frame's background color.

See also #115.