### PR TITLE
Quote $0 in Emacs.sh to handle paths with spaces

### DIFF
--- a/mac/Emacs.app/Contents/MacOS/Emacs.sh
+++ b/mac/Emacs.app/Contents/MacOS/Emacs.sh
@@ -21,7 +21,7 @@
 ### Code:
 
 export EMACS_REINVOKED_FROM_SHELL=1
-[ -L $0 ] && set "$(readlink ${0%.sh})" "$@" || set "${0%.sh}" "$@"
+[ -L "$0" ] && set "$(readlink "${0%.sh}")" "$@" || set "${0%.sh}" "$@"
 
 case ${SHLVL} in
     1) ;;


### PR DESCRIPTION
I ran into this while setting up a second Emacs on my system called `Emacs Canary.app`, which surfaced issues with unquoted paths containing spaces. This change makes the startup script handle that case correctly.