### PR TITLE
docs: Add autoconf to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Briefly:
 ### Install build tools
 
 ```bash
-brew install pkgconf texinfo
+brew install autoconf pkgconf texinfo
 ```
 
 ### Install (optional) libraries


### PR DESCRIPTION
On a new computer, I discovered this was missing when running `./autogen.sh`