### PR TITLE
mac accessibility: avoid keymap access from GUI thread in unsafe windows

### DIFF
--- a/src/macappkit.m
+++ b/src/macappkit.m
@@ -13241,6 +13241,15 @@ is_action_selector (SEL selector)
 {
   NSString *name = NSStringFromSelector (selector);
 
+  /* This runs on the GUI thread, including from synchronous
+     accessibility callbacks (e.g. menu inspection via
+     -respondsToSelector:).  Walking the keymaps below touches Lisp
+     data that the Lisp thread may be altering, so bail out during the
+     windows when such access is unsafe.  */
+  if ((poll_suppress_count == 0 && !NILP (Vinhibit_quit))
+      || gc_in_progress)
+    return NO;
+
   /* The selector name is of the form `ACTIONNAME:' ?  */
   if (NSMaxRange ([name rangeOfString:@":"]) == [name length])
     {


### PR DESCRIPTION
## Problem

On macOS, an external accessibility client inspecting the menu bar can hang Emacs hard (requiring force-quit). I captured two `sample` runs 78s apart plus a system hang report — all show the **same** wedged stack, so it's a true deadlock, not slow progress.

The GUI/main thread faults (SIGSEGV) here:

```
mshMIGPerform → _XCopyAttributeValue → _AXXMIGCopyAttributeValue
  → -[NSMenu(Accessibility) _openForInspection:] → _simulateOpening:
    → _enableItems → _enableItem: → targetForAction:to:from:
      → -[EmacsController respondsToSelector:]
        → is_action_selector → access_keymap → access_keymap_1   ← SIGSEGV
          → handle_sigsegv → deliver_fatal_thread_signal → __sigsuspend   ← GUI thread parked forever
```

Meanwhile the Lisp thread receives the forwarded fatal signal and gets stuck in the orderly-shutdown path (`deliver_fatal_signal → terminate_due_to_signal → shut_down_emacs → kill_buffer_processes`), unable to complete because the GUI thread is suspended mid-AppKit-AX-callback (holding CF/AppKit/AX locks). Net result: a permanent hang instead of a crash.

## Root cause

`is_action_selector` runs on the GUI thread (synchronous accessibility callbacks reach it via `-respondsToSelector:` / menu validation) and walks the Lisp keymaps in `mac-apple-event-map` (`get_keymap`, `access_keymap`, `intern`). When the Lisp thread is mid-mutation — during GC, or the `inhibit-quit`/select-emulation window — that access can fault.

This is the same class of hazard addressed in 627940726de ("mac accessibility: try harder to prevent buffer access issues"), which guarded the buffer-*content* accessors with `(poll_suppress_count == 0 && !NILP (Vinhibit_quit)) || gc_in_progress`. The menu/keymap path was left unguarded.

## Fix

Bail out of `is_action_selector` (returning `NO`) during those same unsafe windows, mirroring the existing buffer-access guards. Outside those windows (real menu-action dispatch) behavior is unchanged; during them, the accessibility/menu probe sees the selector as temporarily not-an-action instead of faulting.