### PR TITLE
mac: fix frame focus under cooperative activation on macOS 14+

### DIFF
--- a/src/macappkit.m
+++ b/src/macappkit.m
@@ -989,7 +989,29 @@ mac_bring_current_process_to_front (bool front_window_only_p)
     }
   if (!front_window_only_p)
     options |= NSApplicationActivateAllWindows;
-  [NSRunningApplication.currentApplication activateWithOptions:options];
+
+#if __clang_major__ >= 9
+  if (@available (macOS 14.0, *))
+#else
+  if ([NSApp respondsToSelector:@selector(activate:)])
+#endif
+    {
+      NSRunningApplication *current = NSRunningApplication.currentApplication;
+      NSRunningApplication *frontmost
+	= NSWorkspace.sharedWorkspace.frontmostApplication;
+
+      /* On macOS 14 and later a process cannot activate itself while
+	 another app is frontmost unless that app yields activation.  When
+	 the Emacs daemon services emacsclient the frontmost app is usually
+	 the invoking terminal, so activate from it to make the request
+	 cooperative; otherwise the frame is raised but never becomes key.  */
+      if (frontmost && ![frontmost isEqual:current])
+	[current activateFromApplication:frontmost options:options];
+      else
+	[current activateWithOptions:options];
+    }
+  else
+    [NSRunningApplication.currentApplication activateWithOptions:options];
 }
 
 /* Move FILENAME to the trash without using the Finder and return


### PR DESCRIPTION
## Problem

On macOS 14+ (reproduced on macOS 26 Tahoe), raising an Emacs frame — e.g. opening a file via `emacsclient` against the daemon — brings the frame forward but it never becomes key/focused; focus has to be given manually.

## Root cause

`mac_bring_current_process_to_front` (src/macappkit.m) uses plain self-activation:

```objc
options = 0;   // on macOS 14+
...
[NSRunningApplication.currentApplication activateWithOptions:options];
```

Under the cooperative-activation model introduced in macOS 14, a process cannot activate **itself** while another app is frontmost unless that app yields activation. When the daemon services `emacsclient`, the frontmost app is the invoking terminal, which never yields — so the frame is ordered front but the app is not activated and the window never becomes key. The pre-14 `NSApplicationActivateIgnoringOtherApps` path is compiled out (`emacs_abort`) at deployment target ≥ 14.

## Fix

Use the cooperative API Apple provides for exactly this case, `-[NSRunningApplication activateFromApplication:options:]` (`activate(from:options:)`, available macOS 14.0+), naming the current frontmost app as the source so the activation is honored. Falls back to `activateWithOptions:` when there is no distinct frontmost app, and the pre-14 path is unchanged.

## Notes

- API verified against `MacOSX26.sdk` (`AppKit/NSRunningApplication.h:144`, `API_AVAILABLE(macos(14.0))`).
- `activateFromApplication:options:` is referenced only inside the `@available(macOS 14.0, *)` branch, so no deprecation/availability warnings.
- **Not yet compiled** — patch authored against the `emacs-mac-30_1_exp` tip; happy to follow up with a build-tested confirmation.