### PR TITLE
mac: support GUI and TTY frames from daemons

### DIFF
--- a/lisp/server.el
+++ b/lisp/server.el
@@ -955,7 +955,7 @@ This handles splitting the command if it would be bigger than
     ;; can not make X frames.
     (cond ((featurep 'ns-win)
 	   (setq w 'ns display "ns"))
-	  ((eq window-system 'mac)
+	  ((featurep 'mac-win)
 	   (setq w 'mac display "Mac"))
           (t
       ;; FIXME! Not sure what this was for, and not sure how it should work
@@ -1340,7 +1340,6 @@ The following commands are accepted by the client:
                  (when (or (and (eq system-type 'windows-nt)
                                 (or (daemonp)
                                     (eq window-system 'w32)))
-                           (eq window-system 'mac)
                            ;; Client runs on Windows, but the server
                            ;; runs on a Posix host.
                            (equal tty-name "CONOUT$"))

--- a/lisp/term/mac-win.el
+++ b/lisp/term/mac-win.el
@@ -3157,8 +3157,9 @@ standard ones in `x-handle-args'."
   (overlay-put mac-ts-active-input-overlay 'display "")
 
   (x-apply-session-resources)
-  (add-to-list 'display-format-alist '("\\`Mac\\'" . mac))
   (setq mac-initialized t))
+
+(add-to-list 'display-format-alist '("\\`Mac\\'" . mac))
 
 (declare-function mac-own-selection-internal "macselect.c"
 		  (selection value &optional frame))

--- a/src/frame.c
+++ b/src/frame.c
@@ -1373,12 +1373,8 @@ affects all frames on the same terminal device.  */)
     emacs_abort ();
 #else /* not MSDOS */
 
-#if defined WINDOWSNT || defined HAVE_MACGUI /* This should work now! */
-  if (sf->output_method != output_termcap
-#ifdef HAVE_MACGUI
-      && sf->output_method != output_initial
-#endif
-      )
+#ifdef WINDOWSNT /* This should work now! */
+  if (sf->output_method != output_termcap)
     error ("Not using an ASCII terminal now; cannot make a new ASCII frame");
 #endif
 #endif /* not MSDOS */

--- a/src/macterm.c
+++ b/src/macterm.c
@@ -5687,6 +5687,10 @@ mac_term_init (Lisp_Object display_name, char *xrm_option, char *resource_name)
 
   gui_init_fringe (terminal->rif);
 
+  /* Startup can inhibit window-system use until the first Mac terminal has
+     finished initialization.  AppKit events must be processed after that.  */
+  inhibit_window_system = false;
+
   unblock_input ();
 
   return dpyinfo;


### PR DESCRIPTION
## Summary

- restore terminal clients for Mac GUI instances
- select the Mac backend when a daemon or terminal frame is current
- register the `Mac` display before window-system initialization
- start AppKit event processing after a daemon initializes its first Mac terminal

## Failure

A frame-less daemon loaded `mac-win`, but `window-system` was nil and the
`Mac` display mapping was installed only during GUI initialization.  Its
first `emacsclient -c` therefore failed with `Don't know how to interpret
display "Mac"` and then fell back to a terminal client.  The daemon also
kept `inhibit_window_system` set after initializing the Mac terminal, so
AppKit events would not be pumped.

The preceding multi-TTY commit restores the Emacs 29 behavior needed for
GUI and terminal clients to coexist in one Mac instance.

## Validation

- `make -j"$(sysctl -n hw.logicalcpu)"`
- `make -C test lisp/server-tests` — 7/7 passed
- `make -C test lib-src/emacsclient-tests` — 2/2 passed
- isolated foreground daemon with a private home and socket directory
- terminal client before GUI initialization and after GUI initialization
- first GUI frame creation, resize, redraw, focus, close, and reopen
- repeated evaluation pings and clean daemon shutdown
