### PR TITLE
mac: prevent frame churn from starving dispatch work

### DIFF
--- a/lisp/server.el
+++ b/lisp/server.el
@@ -955,7 +955,7 @@ This handles splitting the command if it would be bigger than
     ;; can not make X frames.
     (cond ((featurep 'ns-win)
 	   (setq w 'ns display "ns"))
-	  ((eq window-system 'mac)
+	  ((featurep 'mac-win)
 	   (setq w 'mac display "Mac"))
           (t
       ;; FIXME! Not sure what this was for, and not sure how it should work
@@ -1340,7 +1340,6 @@ The following commands are accepted by the client:
                  (when (or (and (eq system-type 'windows-nt)
                                 (or (daemonp)
                                     (eq window-system 'w32)))
-                           (eq window-system 'mac)
                            ;; Client runs on Windows, but the server
                            ;; runs on a Posix host.
                            (equal tty-name "CONOUT$"))

--- a/lisp/term/mac-win.el
+++ b/lisp/term/mac-win.el
@@ -3157,8 +3157,9 @@ standard ones in `x-handle-args'."
   (overlay-put mac-ts-active-input-overlay 'display "")
 
   (x-apply-session-resources)
-  (add-to-list 'display-format-alist '("\\`Mac\\'" . mac))
   (setq mac-initialized t))
+
+(add-to-list 'display-format-alist '("\\`Mac\\'" . mac))
 
 (declare-function mac-own-selection-internal "macselect.c"
 		  (selection value &optional frame))

--- a/src/frame.c
+++ b/src/frame.c
@@ -1373,12 +1373,8 @@ affects all frames on the same terminal device.  */)
     emacs_abort ();
 #else /* not MSDOS */
 
-#if defined WINDOWSNT || defined HAVE_MACGUI /* This should work now! */
-  if (sf->output_method != output_termcap
-#ifdef HAVE_MACGUI
-      && sf->output_method != output_initial
-#endif
-      )
+#ifdef WINDOWSNT /* This should work now! */
+  if (sf->output_method != output_termcap)
     error ("Not using an ASCII terminal now; cannot make a new ASCII frame");
 #endif
 #endif /* not MSDOS */

--- a/src/macappkit.m
+++ b/src/macappkit.m
@@ -2724,6 +2724,8 @@ static void mac_move_frame_window_structure_1 (struct frame *, int, int);
      causes emacsView to receive drawRect: before closing a tabbed
      window on macOS 10.12.  It is too late to remove the view in the
      windowWillClose: delegate method, so we remove it here.  */
+  /* AppKit close animations block one global dispatch worker per frame.  */
+  emacsWindow.animationBehavior = NSWindowAnimationBehaviorNone;
   [emacsView removeFromSuperview];
   [emacsWindow close];
 }
@@ -5756,6 +5758,20 @@ static void mac_end_buffer_and_glyph_matrix_access (void);
 
 @implementation EmacsBacking
 
+static dispatch_queue_t copyFromFrontToBackQueue;
+
++ (void)initialize
+{
+  if (self == EmacsBacking.class)
+    {
+      /* AppKit window animations can saturate the global worker pool while
+         the GUI thread waits for this copy to finish.  */
+      copyFromFrontToBackQueue =
+        dispatch_queue_create ("org.gnu.Emacs.backing-copy",
+                               DISPATCH_QUEUE_SERIAL);
+    }
+}
+
 static vImage_Error
 mac_vimage_buffer_init_8888 (vImage_Buffer *buf, vImagePixelCount height,
 			     vImagePixelCount width)
@@ -5863,11 +5879,9 @@ mac_iosurface_create (size_t width, size_t height)
   NSArrayOf (NSValue *) *rectValues = invalidRectValues;
   invalidRectValues = [[NSMutableArray alloc] initWithCapacity:0];
 
-  dispatch_queue_t queue =
-    dispatch_get_global_queue (DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
   copyFromFrontToBackSemaphore = dispatch_semaphore_create (0);
 
-  dispatch_async (queue, ^{
+  dispatch_async (copyFromFrontToBackQueue, ^{
 #if HAVE_MAC_METAL
       if (backTexture)
 	{
@@ -16650,6 +16664,9 @@ static NSMutableArray *mac_deferred_lisp_queue;
    select emulation.  */
 static dispatch_source_t mac_select_dispatch_source;
 
+/* This must stay runnable when AppKit saturates global dispatch workers.  */
+static dispatch_queue_t mac_select_queue;
+
 /* Command to execute in the GUI thread after the run loop is
    broken.  */
 static enum
@@ -16671,6 +16688,8 @@ mac_init_thread_synchronization (void)
   mac_deferred_lisp_queue = [[NSMutableArray alloc] initWithCapacity:0];
 
   mac_select_next_command = MAC_SELECT_COMMAND_TERMINATE;
+  mac_select_queue =
+    dispatch_queue_create ("org.gnu.Emacs.select", DISPATCH_QUEUE_SERIAL);
   mac_select_dispatch_source =
     dispatch_source_create (DISPATCH_SOURCE_TYPE_DATA_OR, 0, 0,
 			    dispatch_get_main_queue ());
@@ -17141,10 +17160,7 @@ mac_select (int nfds, fd_set *rfds, fd_set *wfds, fd_set *efds,
 	}
       else
 	{
-	  dispatch_queue_t queue =
-	    dispatch_get_global_queue (DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
-
-	  dispatch_async (queue, ^{
+	  dispatch_async (mac_select_queue, ^{
 	      r = pselect (nfds, rfds, wfds, efds, timeout, sigmask);
 	      dispatch_source_merge_data (mac_select_dispatch_source,
 					  MAC_SELECT_COMMAND_TERMINATE);

--- a/src/macterm.c
+++ b/src/macterm.c
@@ -5687,6 +5687,10 @@ mac_term_init (Lisp_Object display_name, char *xrm_option, char *resource_name)
 
   gui_init_fringe (terminal->rif);
 
+  /* Startup can inhibit window-system use until the first Mac terminal has
+     finished initialization.  AppKit events must be processed after that.  */
+  inhibit_window_system = false;
+
   unblock_input ();
 
   return dpyinfo;


### PR DESCRIPTION
Stacked on #143.  The final commit is the dispatch-starvation fix; this
PR will shrink to that commit when #143 lands.

## Summary

- disable AppKit close animations before Emacs frame teardown
- run front-to-back backing copies on a private serial queue
- run the asynchronous `pselect` worker on a separate private serial queue

## Failure

Rapid frame creation and deletion started one blocking AppKit animation
worker per closed frame.  At the 64-thread soft limit, no global worker
remained for Emacs work needed by the GUI thread.  Samples captured the
GUI waiting for a backing copy or select completion while the Lisp thread
waited for the GUI.

Moving only the backing copy exposed the same starvation in the select
worker and image loading.  Disabling close animations removes the worker
leak; the private queues keep the two blocking synchronization paths off
the shared global pool.

## Validation

- `make -j"$(sysctl -n hw.logicalcpu)"`
- `make -C test lisp/server-tests` — 7/7 passed
- `make -C test lib-src/emacsclient-tests` — 2/2 passed
- five regular-GUI trials totaling 250 visible frame create/redraw/delete cycles
- 100 equivalent cycles against a frame-less daemon after its first GUI frame
- final sample reported no dispatch soft-limit saturation
- repeated evaluation pings, GUI close/reopen, and clean shutdown
